### PR TITLE
Drastic revamp of data submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,17 @@ Functionality is split by submodule. They include
   training loops, even the most esoteric. `TrainingStateController` can be used
   to persist model and optimizer states across runs, and manage
   non-determinism.
-- `pydrobert.data`: Primarily serves as a means to manipulate speech data.
+- `pydrobert.torch.data`: Primarily serves as a means to manipulate speech
+  data. It contains subclasses of `torch.utils.data.DataLoader` for both
+  random and sequential access of speech data, as well as examples of how to
+  use them. `pydrobert.torch.data` also contains functions for transducing back
+  and forth between tensors and transcriptions. In particular, this package
+  comes with command line hooks for converting to and from
+  [NIST sclite](http://www1.icsi.berkeley.edu/Speech/docs/sctk-1.2/sclite.htm)
+  file formats. Feature data and senone alignments from
+  [Kaldi](http://kaldi-asr.org/) can be converted to this format using the
+  command line hooks from
+  [pydrobert-kaldi](https://github.com/sdrobert/pydrobert-kaldi).
 
 Consult the submodule docstrings for more information.
 

--- a/pydrobert/torch/command_line.py
+++ b/pydrobert/torch/command_line.py
@@ -56,6 +56,18 @@ def _get_torch_spect_data_dir_info_parse_args(args):
         '--file-suffix', default='.pt',
         help='The file suffix indicating a torch data file'
     )
+    parser.add_argument(
+        '--feat-subdir', default='feat',
+        help='Subdirectory where features are stored'
+    )
+    parser.add_argument(
+        '--ali-subdir', default='ali',
+        help='Subdirectory where alignments are stored'
+    )
+    parser.add_argument(
+        '--ref-subdir', default='ref',
+        help='Subdirectory where reference token sequences are stored'
+    )
     return parser.parse_args(args)
 
 
@@ -65,7 +77,7 @@ def get_torch_spect_data_dir_info(args=None):
     A torch ``SpectDataSet`` data dir is of the form::
 
         dir/
-            feats/
+            feat/
                 <file_prefix><utt1><file_suffix>
                 <file_prefix><utt2><file_suffix>
                 ...
@@ -80,7 +92,7 @@ def get_torch_spect_data_dir_info(args=None):
                 ...
             ]
 
-    Where ``feats`` contains ``FloatTensor``s of shape ``(N, F)``, where
+    Where ``feat`` contains ``FloatTensor``s of shape ``(N, F)``, where
     ``N`` is the number of frames (variable) and ``F`` is the number of
     filters (fixed), ``ali``, if there, contains ``LongTensor``s of shape
     ``(N,)`` indicating the appropriate class labels (likely pdf-ids for
@@ -115,6 +127,9 @@ def get_torch_spect_data_dir_info(args=None):
         options.dir,
         file_prefix=options.file_prefix,
         file_suffix=options.file_suffix,
+        feat_subdir=options.feat_subdir,
+        ali_subdir=options.ali_subdir,
+        ref_subdir=options.ref_subdir,
     )
     if options.strict:
         data.validate_spect_data_set(data_set)

--- a/pydrobert/torch/command_line.py
+++ b/pydrobert/torch/command_line.py
@@ -74,11 +74,21 @@ def get_torch_spect_data_dir_info(args=None):
                 <file_prefix><utt1><file_suffix>
                 ...
             ]
+            [ref/
+                <file_prefix><utt1><file_suffix>
+                <file_prefix><utt1><file_suffix>
+                ...
+            ]
 
     Where ``feats`` contains ``FloatTensor``s of shape ``(N, F)``, where
     ``N`` is the number of frames (variable) and ``F`` is the number of
-    filters (fixed) and ``ali``, if there, contains ``LongTensor``s of shape
-    ``(N,)`` indicating the appropriate class labels.
+    filters (fixed), ``ali``, if there, contains ``LongTensor``s of shape
+    ``(N,)`` indicating the appropriate class labels (likely pdf-ids for
+    discriminative training in an DNN-HMM), and ``ref``, if there,
+    contains ``LongTensor``s of shape ``(R, 3)`` indicating a sequence of
+    reference tokens where element indexed by ``[i, 0]`` is a token id,
+    ``[i, 1]`` is the inclusive start frame of the token (or a negative value
+    if unknown), and ``[i, 2]`` is the exclusive end frame of the token.
 
     This command writes the following space-delimited key-value pairs to an
     output file in sorted order:
@@ -114,7 +124,7 @@ def get_torch_spect_data_dir_info(args=None):
     }
     counts = dict()
     max_class_idx = -1
-    for feat, ali in data_set:
+    for feat, ali, ref in data_set:
         info_dict['num_filts'] = feat.size()[1]
         info_dict['total_frames'] += feat.size()[0]
         if ali is not None:

--- a/pydrobert/torch/command_line.py
+++ b/pydrobert/torch/command_line.py
@@ -377,7 +377,7 @@ def torch_token_data_dir_to_trn(args=None):
         id2token[int(key)] = value
     fpl = len(options.file_prefix)
     neg_fsl = -len(options.file_suffix)
-    utt_ids = (
+    utt_ids = sorted(
         x[fpl:neg_fsl]
         for x in os.listdir(options.dir)
         if x.startswith(options.file_prefix) and

--- a/pydrobert/torch/command_line.py
+++ b/pydrobert/torch/command_line.py
@@ -237,7 +237,8 @@ def trn_to_torch_token_data_dir(args=None):
         options = _trn_to_torch_token_data_dir_parse_args(args)
     except SystemExit as ex:
         return ex.code
-    os.makedirs(options.dir, exist_ok=True)
+    if not os.path.isdir(options.dir):
+        os.makedirs(options.dir)
     token2id = dict()
     for line_no, line in enumerate(options.token2id):
         line = line.strip()

--- a/pydrobert/torch/command_line.py
+++ b/pydrobert/torch/command_line.py
@@ -245,7 +245,7 @@ def trn_to_torch_token_data_dir(args=None):
         if not line:
             continue
         ls = line.split()
-        if len(ls) != 2 or not ls[1].isnumeric():
+        if len(ls) != 2 or not ls[1].isdigit():
             print(
                 'Cannot parse line {} of {}'.format(
                     line_no + 1, options.token2id.name),

--- a/pydrobert/torch/data.py
+++ b/pydrobert/torch/data.py
@@ -12,6 +12,8 @@ import torch
 import torch.utils.data
 import param
 
+from past.builtins import basestring
+
 __author__ = "Sean Robertson"
 __email__ = "sdrobert@cs.toronto.edu"
 __license__ = "Apache 2.0"
@@ -516,7 +518,7 @@ def read_trn(trn, warn=True):
             assert self.parent
             self.tokens = []
             self.parent.tokens[-1].append(self.tokens)
-    if isinstance(trn, str):
+    if isinstance(trn, basestring):
         with open(trn, 'r') as trn:
             return read_trn(trn)
     transcripts = []
@@ -602,12 +604,12 @@ def write_trn(transcripts, trn):
     transcripts : sequence
     trn : file_ptr or str
     '''
-    if isinstance(trn, str):
+    if isinstance(trn, basestring):
         with open(trn, 'w') as trn:
             return write_trn(transcripts, trn)
 
     def _handle_x(x):
-        if isinstance(x, str):
+        if isinstance(x, basestring):
             return x + ' '  # x was a token
         # x is a list of alternates
         ret = []

--- a/pydrobert/torch/data.py
+++ b/pydrobert/torch/data.py
@@ -29,6 +29,7 @@ __all__ = [
     'DataSetParams',
     'EpochRandomSampler',
     'extract_window',
+    'read_trn',
     'REF_PAD_VALUE',
     'spect_seq_to_batch',
     'SpectDataParams',
@@ -39,6 +40,7 @@ __all__ = [
     'token_to_transcript',
     'transcript_to_token',
     'validate_spect_data_set',
+    'write_trn',
 ]
 
 '''The value to right-pad alignments with when batching

--- a/pydrobert/torch/data.py
+++ b/pydrobert/torch/data.py
@@ -776,7 +776,7 @@ def write_ctm(transcripts, ctm, utt2wc='A'):
 
 
 def transcript_to_token(
-        transcript, token2id=None, frame_length_ms=None):
+        transcript, token2id=None, frame_shift_ms=None):
     '''Convert a transcript to a ``SpectDataSet`` token sequence
 
     This method converts `transcript` of length ``R`` to a ``LongTensor`` `tok`
@@ -784,10 +784,10 @@ def transcript_to_token(
     sequence for an utterance of ``SpectDataSet``. An element of `transcript`
     can either be a ``token`` or a 3-tuple of ``(token, start, end)``. ``id =
     token2id.get(token, token) if token2id is not None else token`` dictates
-    the conversion from ``token`` to identifier. If `frame_length_ms` is
+    the conversion from ``token`` to identifier. If `frame_shift_ms` is
     specified, ``start`` and ``end`` are taken as the start and end times, in
     seconds, of the token, and will be converted to frames for `tok`. If
-    `frame_length_ms` is unspecified, ``start`` and ``end`` are assumed to
+    `frame_shift_ms` is unspecified, ``start`` and ``end`` are assumed to
     already be frame times. If ``start`` and ``end`` were unspecified, values
     of ``-1``, representing unknown, will be inserted into ``r[i, 1:]``
 
@@ -795,7 +795,7 @@ def transcript_to_token(
     ----------
     transcript : sequence
     token2id : dict, optional
-    frame_length_ms : int, optional
+    frame_shift_ms : int, optional
 
     Returns
     -------
@@ -807,9 +807,9 @@ def transcript_to_token(
         try:
             if len(token) == 3 and np.isreal(token[1]) and np.isreal(token[2]):
                 token, start, end = token
-                if frame_length_ms:
-                    start = (1000 * start) / frame_length_ms
-                    end = (1000 * end) / frame_length_ms
+                if frame_shift_ms:
+                    start = (1000 * start) / frame_shift_ms
+                    end = (1000 * end) / frame_shift_ms
                 start, end = int(start), int(end)
         except TypeError:
             pass
@@ -822,7 +822,7 @@ def transcript_to_token(
     return tok
 
 
-def token_to_transcript(tok, id2token=None, frame_length_ms=None):
+def token_to_transcript(tok, id2token=None, frame_shift_ms=None):
     '''Convert a ``SpectDataSet`` token sequence to a transcript
 
     The inverse operation of ``transcript_to_token``
@@ -831,7 +831,7 @@ def token_to_transcript(tok, id2token=None, frame_length_ms=None):
     ----------
     tok : torch.LongTensor
     id2token : dict, optional
-    frame_length_ms : int, optional
+    frame_shift_ms : int, optional
 
     Returns
     -------
@@ -846,9 +846,9 @@ def token_to_transcript(tok, id2token=None, frame_length_ms=None):
         if start == -1 or end == -1:
             transcript.append(token)
         else:
-            if frame_length_ms:
-                start = start * frame_length_ms / 1000
-                end = end * frame_length_ms / 1000
+            if frame_shift_ms:
+                start = start * frame_shift_ms / 1000
+                end = end * frame_shift_ms / 1000
             transcript.append((token, start, end))
     return transcript
 

--- a/pydrobert/torch/data.py
+++ b/pydrobert/torch/data.py
@@ -34,6 +34,8 @@ __all__ = [
     'SpectDataSetParams',
     'SpectEvaluationDataLoader',
     'SpectTrainingDataLoader',
+    'token_to_transcript',
+    'transcript_to_token',
     'validate_spect_data_set',
 ]
 
@@ -502,6 +504,37 @@ def transcript_to_token(
         tok[i, 1] = start
         tok[i, 2] = end
     return tok
+
+
+def token_to_transcript(tok, id2token=None, frame_length_ms=None):
+    '''Convert a ``SpectDataSet`` token sequence to a transcript
+
+    The inverse operation of ``transcript_to_token``
+
+    Parameters
+    ----------
+    tok : torch.LongTensor
+    id2token : dict, optional
+    frame_length_ms : int, optional
+
+    Returns
+    -------
+    token : list
+    '''
+    transcript = []
+    for tup in tok:
+        id, start, end = tup.tolist()
+        if id < 0:
+            raise ValueError('id must be non-negative')
+        token = id2token.get(id, id) if id2token is not None else id
+        if start == -1 or end == -1:
+            transcript.append(token)
+        else:
+            if frame_length_ms:
+                start = start * frame_length_ms / 1000
+                end = end * frame_length_ms / 1000
+            transcript.append((token, start, end))
+    return transcript
 
 
 def extract_window(feat, frame_idx, left, right, reverse=False):

--- a/pydrobert/torch/data.py
+++ b/pydrobert/torch/data.py
@@ -551,7 +551,12 @@ class EpochRandomSampler(torch.utils.data.Sampler):
         self.data_source = data_source
         self.epoch = init_epoch
         if base_seed is None:
-            base_seed = np.random.randint(np.iinfo(np.uint32).max)
+            # we use numpy RandomState so that we can run in parallel with
+            # torch's RandomState, but we acquire the initial random seed from
+            # torch so that we'll be deterministic with a prior call to
+            # torch.manual_seed(...)
+            base_seed = torch.randint(
+                np.iinfo(np.int32).max, (1,)).long().item()
         self.base_seed = base_seed
 
     def __len__(self):

--- a/pydrobert/torch/data.py
+++ b/pydrobert/torch/data.py
@@ -453,7 +453,7 @@ def validate_spect_data_set(data_set):
                         0 <= r[1] < r[2] <= feat.shape[0]):
                     raise ValueError(
                         "'{}' (index {}) in '{}', has a reference token "
-                        "(index {}) with bounds outside the utterance"
+                        "(index {}) with invalid boundaries"
                         "".format(
                             data_set.utt_ids[idx] + data_set.file_suffix, idx,
                             os.path.join(

--- a/pydrobert/torch/data.py
+++ b/pydrobert/torch/data.py
@@ -536,10 +536,12 @@ def read_trn(trn, warn=True):
         transcript = []
         token = ''
         alt_tree = AltTree()
+        found_alt = False
         while len(line):
             c = line[0]
             line = line[1:]
             if c == '{':
+                found_alt = True
                 if token:
                     if alt_tree.parent is None:
                         transcript.append(token)
@@ -574,6 +576,13 @@ def read_trn(trn, warn=True):
                 token += c
         if token and alt_tree.parent is None:
             transcript.append(token)
+        if found_alt and warn:
+            warnings.warn(
+                'Found an alternate in transcription for utt="{}". '
+                'Transcript will contain an array of alternates at that '
+                'point, and will not be compatible with transcript_to_token '
+                'until resolved. To suppress this warning, set warn=False'
+                ''.format(utt_id))
         transcripts.append((utt_id, transcript))
     return transcripts
 

--- a/pydrobert/torch/data.py
+++ b/pydrobert/torch/data.py
@@ -17,19 +17,22 @@ __email__ = "sdrobert@cs.toronto.edu"
 __license__ = "Apache 2.0"
 __copyright__ = "Copyright 2018 Sean Robertson"
 __all__ = [
-    'extract_window',
-    'SpectDataSet',
-    'validate_spect_data_set',
-    'ContextWindowDataSet',
-    'EpochRandomSampler',
     'context_window_seq_to_batch',
-    'DataSetParams',
-    'SpectDataParams',
     'ContextWindowDataParams',
-    'SpectDataSetParams',
+    'ContextWindowDataSet',
     'ContextWindowDataSetParams',
-    'ContextWindowTrainingDataLoader',
     'ContextWindowEvaluationDataLoader',
+    'ContextWindowTrainingDataLoader',
+    'DataSetParams',
+    'EpochRandomSampler',
+    'extract_window',
+    'spect_seq_to_batch',
+    'SpectDataParams',
+    'SpectDataSet',
+    'SpectDataSetParams',
+    'SpectEvaluationDataLoader',
+    'SpectTrainingDataLoader',
+    'validate_spect_data_set',
 ]
 
 
@@ -727,10 +730,10 @@ class SpectTrainingDataLoader(torch.utils.data.DataLoader):
             raise ValueError(
                 "'{}' must have either alignments or reference tokens for "
                 "training".format(data_dir))
-        self.__sampler = EpochRandomSampler(
+        epoch_sampler = EpochRandomSampler(
             self.data_source, init_epoch=init_epoch, base_seed=params.seed)
         batch_sampler = torch.utils.data.BatchSampler(
-            self.__sampler, params.batch_size, drop_last=params.drop_last)
+            epoch_sampler, params.batch_size, drop_last=params.drop_last)
         super(SpectTrainingDataLoader, self).__init__(
             self.data_source,
             batch_sampler=batch_sampler,
@@ -741,11 +744,11 @@ class SpectTrainingDataLoader(torch.utils.data.DataLoader):
     @property
     def epoch(self):
         '''int : the current epoch'''
-        return self.__sampler.epoch
+        return self.batch_sampler.sampler.epoch
 
     @epoch.setter
     def epoch(self, val):
-        self.__sampler.epoch = val
+        self.batch_sampler.sampler.epoch = val
 
 
 class SpectEvaluationDataLoader(torch.utils.data.DataLoader):
@@ -958,10 +961,10 @@ class ContextWindowTrainingDataLoader(torch.utils.data.DataLoader):
             raise ValueError(
                 "'{}' must have alignment info for training".format(
                     data_dir))
-        self.__sampler = EpochRandomSampler(
+        epoch_sampler = EpochRandomSampler(
             self.data_source, init_epoch=init_epoch, base_seed=params.seed)
         batch_sampler = torch.utils.data.BatchSampler(
-            self.__sampler, params.batch_size, drop_last=params.drop_last)
+            epoch_sampler, params.batch_size, drop_last=params.drop_last)
         super(ContextWindowTrainingDataLoader, self).__init__(
             self.data_source,
             batch_sampler=batch_sampler,
@@ -972,11 +975,11 @@ class ContextWindowTrainingDataLoader(torch.utils.data.DataLoader):
     @property
     def epoch(self):
         '''int : the current epoch'''
-        return self.__sampler.epoch
+        return self.batch_sampler.sampler.epoch
 
     @epoch.setter
     def epoch(self, val):
-        self.__sampler.epoch = val
+        self.batch_sampler.sampler.epoch = val
 
 
 class ContextWindowEvaluationDataLoader(torch.utils.data.DataLoader):

--- a/pydrobert/torch/data.py
+++ b/pydrobert/torch/data.py
@@ -421,9 +421,9 @@ def validate_spect_data_set(data_set):
                     "".format(
                         data_set.utt_ids[idx] + data_set.file_suffix, idx,
                         os.path.join(data_set.data_dir, data_set.ref_subdir)))
-            for idx2, r in enum(ref):
-                if not (r[1] < 0 and r[2] < 0) or not (
-                        0 <= r[1] < r[2] < feats.shape[0]):
+            for idx2, r in enumerate(ref):
+                if not (r[1] < 0 and r[2] < 0) and not (
+                        0 <= r[1] < r[2] <= feats.shape[0]):
                     raise ValueError(
                         "'{}' (index {}) in '{}', has a reference token "
                         "(index {}) with bounds outside the utterance"

--- a/pydrobert/torch/data.py
+++ b/pydrobert/torch/data.py
@@ -236,7 +236,7 @@ class SpectDataSet(torch.utils.data.Dataset):
             neg_fsl = None
         fpl = len(self.file_prefix)
         utt_ids = set(
-            os.path.basename(x)[fpl:neg_fsl]
+            x[fpl:neg_fsl]
             for x in os.listdir(os.path.join(self.data_dir, self.feat_subdir))
             if x.startswith(self.file_prefix) and x.endswith(self.file_suffix)
         )
@@ -244,7 +244,7 @@ class SpectDataSet(torch.utils.data.Dataset):
             utt_ids &= subset_ids
         if self.has_ali:
             ali_utt_ids = set(
-                os.path.basename(x)[fpl:neg_fsl]
+                x[fpl:neg_fsl]
                 for x in os.listdir(
                     os.path.join(self.data_dir, self.ali_subdir))
                 if x.startswith(self.file_prefix) and
@@ -260,7 +260,7 @@ class SpectDataSet(torch.utils.data.Dataset):
                         "Missing feat for uttid: '{}'".format(utt_id))
         if self.has_ref:
             ref_utt_ids = set(
-                os.path.basename(x)[fpl:neg_fsl]
+                x[fpl:neg_fsl]
                 for x in os.listdir(
                     os.path.join(self.data_dir, self.ref_subdir))
                 if x.startswith(self.file_prefix) and

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ def main():
         ],
         entry_points={
             'console_scripts': [
+                'ctm-to-torch-token-data-dir = pydrobert.torch.command_line:'
+                'ctm_to_torch_token_data_dir',
                 'get-torch-spect-data-dir-info = pydrobert.torch.command_line:'
                 'get_torch_spect_data_dir_info',
                 'trn-to-torch-token-data-dir = pydrobert.torch.command_line:'

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,8 @@ def main():
                 'get_torch_spect_data_dir_info',
                 'trn-to-torch-token-data-dir = pydrobert.torch.command_line:'
                 'trn_to_torch_token_data_dir',
+                'torch-token-data-dir-to-trn = pydrobert.torch.command_line:'
+                'torch_token_data_dir_to_trn',
             ]
         },
     )

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,9 @@ def main():
         entry_points={
             'console_scripts': [
                 'get-torch-spect-data-dir-info = pydrobert.torch.command_line:'
-                'get_torch_spect_data_dir_info'
+                'get_torch_spect_data_dir_info',
+                'trn-to-torch-token-data-dir = pydrobert.torch.command_line:'
+                'trn_to_torch_token_data_dir',
             ]
         },
     )

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,8 @@ def main():
                 'get_torch_spect_data_dir_info',
                 'trn-to-torch-token-data-dir = pydrobert.torch.command_line:'
                 'trn_to_torch_token_data_dir',
+                'torch-token-data-dir-to-ctm = pydrobert.torch.command_line:'
+                'torch_token_data_dir_to_ctm',
                 'torch-token-data-dir-to-trn = pydrobert.torch.command_line:'
                 'torch_token_data_dir_to_trn',
             ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,11 +41,11 @@ def populate_torch_dir():
             include_ali=True, include_ref=True, file_prefix='',
             file_suffix='.pt', seed=1):
         torch.manual_seed(seed)
-        feats_dir = os.path.join(dr, 'feats')
+        feat_dir = os.path.join(dr, 'feat')
         ali_dir = os.path.join(dr, 'ali')
         ref_dir = os.path.join(dr, 'ref')
-        if not os.path.isdir(feats_dir):
-            os.makedirs(feats_dir)
+        if not os.path.isdir(feat_dir):
+            os.makedirs(feat_dir)
         if include_ali and not os.path.isdir(ali_dir):
             os.makedirs(ali_dir)
         if include_ref and not os.path.isdir(ref_dir):
@@ -60,7 +60,7 @@ def populate_torch_dir():
             feat_size = feat_size.item()
             feat = torch.rand(feat_size, num_filts)
             torch.save(feat, os.path.join(
-                feats_dir, file_prefix + utt_id + file_suffix))
+                feat_dir, file_prefix + utt_id + file_suffix))
             feats.append(feat)
             feat_sizes.append(feat_size)
             utt_ids.append(utt_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,11 +70,11 @@ def populate_torch_dir():
                     ali_dir, file_prefix + utt_id + file_suffix))
                 alis.append(ali)
             if include_ref:
-                ref_size = torch.randint(1, max_width + 1, (1,)).long().item()
-                max_ref_length = torch.randint(1, max_width, (1,)).long()
+                ref_size = torch.randint(1, feat_size + 1, (1,)).long().item()
+                max_ref_length = torch.randint(1, feat_size + 1, (1,)).long()
                 max_ref_length = max_ref_length.item()
                 ref_starts = torch.randint(
-                    max_width - max_ref_length, (ref_size,)).long()
+                    feat_size - max_ref_length + 1, (ref_size,)).long()
                 ref_lengths = torch.randint(
                     1, max_ref_length + 1, (ref_size,)).long()
                 ref = torch.stack([

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,16 +38,21 @@ def populate_torch_dir():
     def _populate_torch_dir(
             dr, num_utts, min_width=1, max_width=10, num_filts=5,
             max_class=10,
-            include_ali=True, file_prefix='', file_suffix='.pt', seed=1):
+            include_ali=True, include_ref=True, file_prefix='',
+            file_suffix='.pt', seed=1):
         torch.manual_seed(seed)
         feats_dir = os.path.join(dr, 'feats')
         ali_dir = os.path.join(dr, 'ali')
+        ref_dir = os.path.join(dr, 'ref')
         if not os.path.isdir(feats_dir):
             os.makedirs(feats_dir)
         if include_ali and not os.path.isdir(ali_dir):
             os.makedirs(ali_dir)
+        if include_ref and not os.path.isdir(ref_dir):
+            os.makedirs(ref_dir)
         feats, feat_sizes, utt_ids = [], [], []
         alis = [] if include_ali else None
+        refs, ref_sizes = ([], []) if include_ref else (None, None)
         utt_id_fmt_str = '{{:0{}d}}'.format(int(math.log10(num_utts)) + 1)
         for utt_idx in range(num_utts):
             utt_id = utt_id_fmt_str.format(utt_idx)
@@ -64,5 +69,22 @@ def populate_torch_dir():
                 torch.save(ali, os.path.join(
                     ali_dir, file_prefix + utt_id + file_suffix))
                 alis.append(ali)
-        return feats, alis, feat_sizes, utt_ids
+            if include_ref:
+                ref_size = torch.randint(1, max_width + 1, (1,)).long().item()
+                max_ref_length = torch.randint(1, max_width, (1,)).long()
+                max_ref_length = max_ref_length.item()
+                ref_starts = torch.randint(
+                    max_width - max_ref_length, (ref_size,)).long()
+                ref_lengths = torch.randint(
+                    1, max_ref_length + 1, (ref_size,)).long()
+                ref = torch.stack([
+                    torch.randint(100, (ref_size,)).long(),
+                    ref_starts,
+                    ref_starts + ref_lengths,
+                ], dim=-1)
+                torch.save(ref, os.path.join(
+                    ref_dir, file_prefix + utt_id + file_suffix))
+                ref_sizes.append(ref_size)
+                refs.append(ref)
+        return feats, alis, refs, feat_sizes, ref_sizes, utt_ids
     return _populate_torch_dir

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -19,7 +19,7 @@ def test_get_torch_spect_data_dir_info(temp_dir, populate_torch_dir):
     _, alis, _, feat_sizes, _, _ = populate_torch_dir(
         temp_dir, 19, num_filts=5, max_class=10)
     # add one with class idx 10 to ensure all classes are accounted for
-    torch.save(torch.rand(1, 5), os.path.join(temp_dir, 'feats', 'utt19.pt'))
+    torch.save(torch.rand(1, 5), os.path.join(temp_dir, 'feat', 'utt19.pt'))
     torch.save(torch.tensor([10]), os.path.join(temp_dir, 'ali', 'utt19.pt'))
     torch.save(
         torch.tensor([[0, 0, 1]]), os.path.join(temp_dir, 'ref', 'utt19.pt'))
@@ -41,7 +41,7 @@ def test_get_torch_spect_data_dir_info(temp_dir, populate_torch_dir):
         key = 'count_{:02d}'.format(class_idx)
         assert table[key] == alis.count(class_idx)
     # invalidate the data set and try again
-    torch.save(torch.rand(1, 4), os.path.join(temp_dir, 'feats', 'utt19.pt'))
+    torch.save(torch.rand(1, 4), os.path.join(temp_dir, 'feat', 'utt19.pt'))
     with pytest.raises(ValueError):
         command_line.get_torch_spect_data_dir_info(
             [temp_dir, table_path, '--strict'])

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -22,7 +22,7 @@ def test_get_torch_spect_data_dir_info(temp_dir, populate_torch_dir):
     torch.save(torch.rand(1, 5), os.path.join(temp_dir, 'feat', 'utt19.pt'))
     torch.save(torch.tensor([10]), os.path.join(temp_dir, 'ali', 'utt19.pt'))
     torch.save(
-        torch.tensor([[0, 0, 1]]), os.path.join(temp_dir, 'ref', 'utt19.pt'))
+        torch.tensor([[100, 0, 1]]), os.path.join(temp_dir, 'ref', 'utt19.pt'))
     feat_sizes += (1,)
     alis = torch.cat(alis + [torch.tensor([10])])
     alis = [class_idx.item() for class_idx in alis]
@@ -37,6 +37,8 @@ def test_get_torch_spect_data_dir_info(temp_dir, populate_torch_dir):
     assert table['num_utterances'] == 20
     assert table['total_frames'] == sum(feat_sizes)
     assert table['num_filts'] == 5
+    assert table['max_ali_class'] == 10
+    assert table['max_ref_class'] == 100
     for class_idx in range(11):
         key = 'count_{:02d}'.format(class_idx)
         assert table[key] == alis.count(class_idx)

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -16,11 +16,13 @@ __copyright__ = "Copyright 2018 Sean Robertson"
 
 @pytest.mark.cpu
 def test_get_torch_spect_data_dir_info(temp_dir, populate_torch_dir):
-    _, alis, feat_sizes, _ = populate_torch_dir(
+    _, alis, _, feat_sizes, _, _ = populate_torch_dir(
         temp_dir, 19, num_filts=5, max_class=10)
     # add one with class idx 10 to ensure all classes are accounted for
     torch.save(torch.rand(1, 5), os.path.join(temp_dir, 'feats', 'utt19.pt'))
     torch.save(torch.tensor([10]), os.path.join(temp_dir, 'ali', 'utt19.pt'))
+    torch.save(
+        torch.tensor([[0, 0, 1]]), os.path.join(temp_dir, 'ref', 'utt19.pt'))
     feat_sizes += (1,)
     alis = torch.cat(alis + [torch.tensor([10])])
     alis = [class_idx.item() for class_idx in alis]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -206,7 +206,7 @@ def test_spect_data_set_validity(temp_dir):
 @pytest.mark.cpu
 def test_read_trn():
     trn = StringIO()
-    trn.write('''\
+    trn.write(u'''\
 here is a simple example (a)
 nothing should go wrong (b)
 ''')
@@ -217,7 +217,7 @@ nothing should go wrong (b)
         ('b', ['nothing', 'should', 'go', 'wrong']),
     ]
     trn.seek(0)
-    trn.write('''\
+    trn.write(u'''\
 here is an { example /with} some alternates (a)
 } and /here/ is {something really / {really}} (stupid) { ignore this (b)
 ''')

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -101,12 +101,12 @@ def test_valid_spect_data_set(
 @pytest.mark.cpu
 def test_spect_data_set_warnings(temp_dir):
     torch.manual_seed(1)
-    feats_dir = os.path.join(temp_dir, 'feats')
+    feat_dir = os.path.join(temp_dir, 'feat')
     ali_dir = os.path.join(temp_dir, 'ali')
-    os.makedirs(feats_dir)
+    os.makedirs(feat_dir)
     os.makedirs(ali_dir)
-    torch.save(torch.rand(3, 3), os.path.join(feats_dir, 'a.pt'))
-    torch.save(torch.rand(4, 3), os.path.join(feats_dir, 'b.pt'))
+    torch.save(torch.rand(3, 3), os.path.join(feat_dir, 'a.pt'))
+    torch.save(torch.rand(4, 3), os.path.join(feat_dir, 'b.pt'))
     torch.save(torch.randint(10, (4,)).long(), os.path.join(ali_dir, 'b.pt'))
     torch.save(torch.randint(10, (5,)).long(), os.path.join(ali_dir, 'c.pt'))
     data_set = data.SpectDataSet(temp_dir, warn_on_missing=False)
@@ -118,14 +118,14 @@ def test_spect_data_set_warnings(temp_dir):
     assert any(
         str(x.message) == "Missing ali for uttid: 'a'" for x in warnings)
     assert any(
-        str(x.message) == "Missing feats for uttid: 'c'" for x in warnings)
+        str(x.message) == "Missing feat for uttid: 'c'" for x in warnings)
 
 
 def test_spect_data_write_pdf(temp_dir, device):
     torch.manual_seed(1)
-    feats_dir = os.path.join(temp_dir, 'feats')
-    os.makedirs(feats_dir)
-    torch.save(torch.rand(3, 3), os.path.join(feats_dir, 'a.pt'))
+    feat_dir = os.path.join(temp_dir, 'feat')
+    os.makedirs(feat_dir)
+    torch.save(torch.rand(3, 3), os.path.join(feat_dir, 'a.pt'))
     data_set = data.SpectDataSet(temp_dir)
     z = torch.randint(10, (4, 5)).long()
     if device == 'cuda':
@@ -143,9 +143,9 @@ def test_spect_data_write_pdf(temp_dir, device):
 
 def test_spect_data_write_hyp(temp_dir, device):
     torch.manual_seed(1)
-    feats_dir = os.path.join(temp_dir, 'feats')
-    os.makedirs(feats_dir)
-    torch.save(torch.rand(3, 3), os.path.join(feats_dir, 'a.pt'))
+    feat_dir = os.path.join(temp_dir, 'feat')
+    os.makedirs(feat_dir)
+    torch.save(torch.rand(3, 3), os.path.join(feat_dir, 'a.pt'))
     data_set = data.SpectDataSet(temp_dir)
     z = torch.randint(10, (4, 3))
     if device == 'cuda':
@@ -164,13 +164,13 @@ def test_spect_data_write_hyp(temp_dir, device):
 @pytest.mark.cpu
 def test_spect_data_set_validity(temp_dir):
     torch.manual_seed(1)
-    feats_dir = os.path.join(temp_dir, 'feats')
+    feat_dir = os.path.join(temp_dir, 'feat')
     ali_dir = os.path.join(temp_dir, 'ali')
-    feats_a_pt = os.path.join(feats_dir, 'a.pt')
-    feats_b_pt = os.path.join(feats_dir, 'b.pt')
+    feats_a_pt = os.path.join(feat_dir, 'a.pt')
+    feats_b_pt = os.path.join(feat_dir, 'b.pt')
     ali_a_pt = os.path.join(ali_dir, 'a.pt')
     ali_b_pt = os.path.join(ali_dir, 'b.pt')
-    os.makedirs(feats_dir)
+    os.makedirs(feat_dir)
     os.makedirs(ali_dir)
     torch.save(torch.rand(10, 4), feats_a_pt)
     torch.save(torch.rand(4, 4), feats_b_pt)
@@ -206,10 +206,10 @@ def test_spect_data_set_validity(temp_dir):
 @pytest.mark.parametrize('reverse', [True, False])
 def test_context_window_data_set(temp_dir, reverse):
     torch.manual_seed(1)
-    feats_dir = os.path.join(temp_dir, 'feats')
-    os.makedirs(feats_dir)
+    feat_dir = os.path.join(temp_dir, 'feat')
+    os.makedirs(feat_dir)
     a = torch.rand(2, 10)
-    torch.save(a, os.path.join(feats_dir, 'a.pt'))
+    torch.save(a, os.path.join(feat_dir, 'a.pt'))
     data_set = data.ContextWindowDataSet(temp_dir, 1, 1, reverse=reverse)
     windowed, _ = data_set[0]
     assert tuple(windowed.shape) == (2, 3, 10)
@@ -414,9 +414,9 @@ def test_spect_training_data_loader(temp_dir, populate_torch_dir):
 @pytest.mark.cpu
 def test_spect_evaluation_data_loader(temp_dir, populate_torch_dir):
     torch.manual_seed(41)
-    feats_dir = os.path.join(temp_dir, 'feats')
+    feat_dir = os.path.join(temp_dir, 'feat')
     ali_dir = os.path.join(temp_dir, 'ali')
-    os.makedirs(feats_dir)
+    os.makedirs(feat_dir)
     os.makedirs(ali_dir)
     p = data.SpectDataSetParams(batch_size=5)
     feats, ali, ref, feat_sizes, ref_sizes, utt_ids = populate_torch_dir(
@@ -491,12 +491,12 @@ def test_window_training_data_loader(temp_dir, populate_torch_dir):
     assert total_windows_ep0 >= 5
     feats_ep1_a, alis_ep1_a = [], []
     total_windows_ep1 = 0
-    for feat, ali in data_loader:
+    for feats, alis in data_loader:
         windows = feat.shape[0]
         assert tuple(feat.shape) == (windows, 3, 2)
         assert tuple(ali.shape) == (windows,)
-        feats_ep1_a.append(feat)
-        alis_ep1_a.append(ali)
+        feats_ep1_a.append(feats)
+        alis_ep1_a.append(alis)
         total_windows_ep1 += windows
     assert total_windows_ep0 == total_windows_ep1
     data_loader = data.ContextWindowTrainingDataLoader(
@@ -505,38 +505,38 @@ def test_window_training_data_loader(temp_dir, populate_torch_dir):
         num_workers=4,
     )
     feats_ep1_b, alis_ep1_b = [], []
-    for feat, ali in data_loader:
-        feats_ep1_b.append(feat)
-        alis_ep1_b.append(ali)
+    for feats, alis in data_loader:
+        feats_ep1_b.append(feats)
+        alis_ep1_b.append(alis)
     assert all(
-        torch.allclose(feat_a, feat_b)
-        for (feat_a, feat_b) in zip(feats_ep1_a, feats_ep1_b)
+        torch.allclose(feats_a, feats_b)
+        for (feats_a, feats_b) in zip(feats_ep1_a, feats_ep1_b)
     )
     assert all(
-        torch.allclose(ali_a.float(), ali_b.float())
-        for (ali_a, ali_b) in zip(alis_ep1_a, alis_ep1_b)
+        torch.allclose(alis_a.float(), alis_b.float())
+        for (alis_a, alis_b) in zip(alis_ep1_a, alis_ep1_b)
     )
     data_loader.epoch = 1
     feats_ep1_c, alis_ep1_c = [], []
-    for feat, ali in data_loader:
-        feats_ep1_c.append(feat)
-        alis_ep1_c.append(ali)
+    for feats, alis in data_loader:
+        feats_ep1_c.append(feats)
+        alis_ep1_c.append(alis)
     assert all(
-        torch.allclose(feat_a, feat_c)
-        for (feat_a, feat_c) in zip(feats_ep1_a, feats_ep1_c)
+        torch.allclose(feats_a, feats_c)
+        for (feats_a, feats_c) in zip(feats_ep1_a, feats_ep1_c)
     )
     assert all(
-        torch.allclose(ali_a.float(), ali_c.float())
-        for (ali_a, ali_c) in zip(alis_ep1_a, alis_ep1_c)
+        torch.allclose(alis_a.float(), alis_c.float())
+        for (alis_a, alis_c) in zip(alis_ep1_a, alis_ep1_c)
     )
 
 
 @pytest.mark.cpu
 def test_window_evaluation_data_loader(temp_dir, populate_torch_dir):
     torch.manual_seed(1)
-    feats_dir = os.path.join(temp_dir, 'feats')
+    feat_dir = os.path.join(temp_dir, 'feat')
     ali_dir = os.path.join(temp_dir, 'ali')
-    os.makedirs(feats_dir)
+    os.makedirs(feat_dir)
     os.makedirs(ali_dir)
     p = data.ContextWindowDataSetParams(
         context_left=1,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -222,7 +222,7 @@ here is an { example /with} some alternates (a)
 } and /here/ is {something really / {really}} (stupid) { ignore this (b)
 ''')
     trn.seek(0)
-    act = data.read_trn(trn)
+    act = data.read_trn(trn, warn=False)
     assert act == [
         ('a', [
             'here', 'is', 'an',

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -271,7 +271,7 @@ def test_context_window_seq_to_batch(feat_sizes, include_ali):
 
 
 @pytest.mark.cpu
-def test_training_data_loader(temp_dir, populate_torch_dir):
+def test_window_training_data_loader(temp_dir, populate_torch_dir):
     populate_torch_dir(temp_dir, 5, num_filts=2)
     p = data.ContextWindowDataSetParams(
         context_left=1,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -241,6 +241,13 @@ def test_epoch_random_sampler(temp_dir):
     sampler = data.EpochRandomSampler(data_source, init_epoch=10, base_seed=1)
     assert samples_ep0 == tuple(sampler.get_samples_for_epoch(0))
     assert samples_ep1 == tuple(sampler.get_samples_for_epoch(1))
+    # should be reproducible if we set torch manual seed
+    torch.manual_seed(5)
+    sampler = data.EpochRandomSampler(data_source)
+    samples_ep0 = tuple(sampler)
+    torch.manual_seed(5)
+    sampler = data.EpochRandomSampler(data_source)
+    assert samples_ep0 == tuple(sampler)
 
 
 @pytest.mark.cpu

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -203,6 +203,28 @@ def test_spect_data_set_validity(temp_dir):
 
 
 @pytest.mark.cpu
+@pytest.mark.parametrize('transcript,token2id,exp', [
+    ([], None, torch.LongTensor(0, 3)),
+    (
+        [1, 2, 3, 4],
+        None,
+        torch.LongTensor([[1, -1, -1], [2, -1, -1], [3, -1, -1], [4, -1, -1]])
+    ),
+    (
+        [1, ('a', 4, 10), 'a', 3],
+        {'a': 2},
+        torch.LongTensor([[1, -1, -1], [2, 4, 10], [2, -1, -1], [3, -1, -1]]),
+    ),
+])
+def test_transcript_to_token(transcript, token2id, exp):
+    act = data.transcript_to_token(transcript, token2id)
+    assert torch.all(exp == act)
+    transcript = ['foo'] + transcript
+    with pytest.raises(Exception):
+        data.transcript_to_token(transcript, token2id)
+
+
+@pytest.mark.cpu
 @pytest.mark.parametrize('reverse', [True, False])
 def test_context_window_data_set(temp_dir, reverse):
     torch.manual_seed(1)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -220,6 +220,7 @@ nothing should go wrong (b)
     trn.write(u'''\
 here is an { example /with} some alternates (a)
 } and /here/ is {something really / {really}} (stupid) { ignore this (b)
+(c)
 ''')
     trn.seek(0)
     act = data.read_trn(trn, warn=False)
@@ -231,8 +232,38 @@ here is an { example /with} some alternates (a)
             '}', 'and', '/here/', 'is',
             ([['something', 'really'], [[['really']]]], -1, -1),
             '(stupid)'
-        ])
+        ]),
+        ('c', []),
     ]
+
+
+@pytest.mark.cpu
+def test_write_trn():
+    trn = StringIO()
+    transcripts = [
+        ('a', ['again', 'a', 'simple', 'example']),
+        ('b', ['should', 'get', 'right', 'no', 'prob']),
+    ]
+    data.write_trn(transcripts, trn)
+    trn.seek(0)
+    assert u'''\
+again a simple example (a)
+should get right no prob (b)
+''' == trn.read()
+    trn.seek(0)
+    transcripts = [
+        (' c ', [
+            ('unnecessary', -1, -1),
+            ([['complexity', [['can']]], ['also', 'be']], 10, 4),
+            'handled']),
+        ('d', []),
+    ]
+    data.write_trn(transcripts, trn)
+    trn.seek(0)
+    assert u'''\
+unnecessary { complexity { can } / also be } handled ( c )
+(d)
+''' == trn.read()
 
 
 @pytest.mark.cpu

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -61,6 +61,10 @@ def test_valid_spect_data_set(
     # prefix. If there is, these ought to be ignored by the data set
     populate_torch_dir(
         temp_dir, num_utts, include_ali=False, include_ref=False)
+    if not os.path.isdir(os.path.join(temp_dir, 'feat', 'fake')):
+        os.makedirs(os.path.join(temp_dir, 'feat', 'fake'))
+    torch.save(torch.rand(10, 5), os.path.join(
+        temp_dir, 'feat', 'fake', file_prefix + 'fake.pt'))
     data_set = data.SpectDataSet(temp_dir, file_prefix=file_prefix)
     assert not data_set.has_ali and not data_set.has_ref
     assert len(utt_ids) == len(data_set.utt_ids)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -309,7 +309,7 @@ def test_spect_seq_to_batch(include_ali, include_ref):
     if include_ali:
         assert all(
             torch.all(a[:b.shape[0]] == b) and
-            torch.all(a[b.shape[0]:] == torch.tensor([-1]))
+            torch.all(a[b.shape[0]:] == torch.tensor([data.ALI_PAD_VALUE]))
             for (a, b) in zip(batch_ali, alis)
         )
     else:
@@ -318,7 +318,7 @@ def test_spect_seq_to_batch(include_ali, include_ref):
         assert ref_sizes == batch_ref_sizes
         assert all(
             torch.all(a[:b.shape[0]] == b) and
-            torch.all(a[b.shape[0]:] == torch.tensor([-1]))
+            torch.all(a[b.shape[0]:] == torch.tensor([data.REF_PAD_VALUE]))
             for (a, b) in zip(batch_ref, refs)
         )
     else:
@@ -371,10 +371,10 @@ def test_spect_training_data_loader(temp_dir, populate_torch_dir):
                 ep_feats[i], (0, 0, 0, max_T - ep_ali[i].shape[0]))
             ep_ali[i] = torch.nn.functional.pad(
                 ep_ali[i], (0, max_T - ep_ali[i].shape[0]),
-                value=-1)
+                value=data.ALI_PAD_VALUE)
             ep_ref[i] = torch.nn.functional.pad(
                 ep_ref[i], (0, 0, 0, max_R - ep_ref[i].shape[0]),
-                value=-1)
+                value=data.REF_PAD_VALUE)
         if sort:
             ep_feats, ep_ali, ep_ref, ep_feat_sizes, ep_ref_sizes = zip(
                 *sorted(
@@ -457,10 +457,12 @@ def test_spect_evaluation_data_loader(temp_dir, populate_torch_dir):
                 assert torch.allclose(a[b.shape[0]:], torch.tensor([0.]))
             for a, b in zip(b_ali, s_ali):
                 assert torch.all(a[:b.shape[0]] == b)
-                assert torch.all(a[b.shape[0]:] == torch.tensor([-1]))
+                assert torch.all(a[b.shape[0]:] == torch.tensor(
+                    [data.ALI_PAD_VALUE]))
             for a, b in zip(b_ref, s_ref):
                 assert torch.all(a[:b.shape[0]] == b)
-                assert torch.all(a[b.shape[0]:] == torch.tensor([-1]))
+                assert torch.all(a[b.shape[0]:] == torch.tensor(
+                    [data.REF_PAD_VALUE]))
             cur_idx += 5
 
     _compare_data_loader()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -300,7 +300,7 @@ def test_spect_seq_to_batch(include_ali, include_ref):
         data.spect_seq_to_batch(zip(feats, alis, refs)))
     feat_sizes, feats, alis, refs, ref_sizes = zip(*sorted(
         zip(feat_sizes, feats, alis, refs, ref_sizes), key=lambda x: -x[0]))
-    assert feat_sizes == batch_feat_sizes
+    assert torch.all(torch.tensor(feat_sizes) == batch_feat_sizes)
     assert all(
         torch.allclose(a[:b.shape[0]], b) and
         torch.allclose(a[b.shape[0]:], torch.tensor([0.]))
@@ -315,7 +315,7 @@ def test_spect_seq_to_batch(include_ali, include_ref):
     else:
         assert batch_ali is None
     if include_ref:
-        assert ref_sizes == batch_ref_sizes
+        assert torch.all(torch.tensor(ref_sizes) == batch_ref_sizes)
         assert all(
             torch.all(a[:b.shape[0]] == b) and
             torch.all(a[b.shape[0]:] == torch.tensor([data.REF_PAD_VALUE]))
@@ -362,8 +362,8 @@ def test_spect_training_data_loader(temp_dir, populate_torch_dir):
             ep_feats += tuple(b_feats)
             ep_ali += tuple(b_ali)
             ep_ref += tuple(b_ref)
-            ep_feat_sizes += b_feat_sizes
-            ep_ref_sizes += b_ref_sizes
+            ep_feat_sizes += tuple(b_feat_sizes)
+            ep_ref_sizes += tuple(b_ref_sizes)
         assert len(ep_feats) == num_utts
         assert len(ep_ali) == num_utts
         for i in range(num_utts):
@@ -450,8 +450,8 @@ def test_spect_evaluation_data_loader(temp_dir, populate_torch_dir):
                         utt_ids[cur_idx:cur_idx + 5]),
                     key=lambda x: -x[3])))
             assert b_utt_ids == s_utt_ids
-            assert b_feat_sizes == s_feat_sizes
-            assert b_ref_sizes == s_ref_sizes
+            assert tuple(b_feat_sizes) == s_feat_sizes
+            assert tuple(b_ref_sizes) == s_ref_sizes
             for a, b in zip(b_feats, s_feats):
                 assert torch.allclose(a[:b.shape[0]], b)
                 assert torch.allclose(a[b.shape[0]:], torch.tensor([0.]))

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -273,7 +273,7 @@ def test_spect_seq_to_batch(include_ali, include_ref):
     torch.manual_seed(1)
     feat_sizes = tuple(
         torch.randint(1, 30, (1,)).long().item()
-        for _ in range(torch.randint(3, 10, (1,)).long().item()),
+        for _ in range(torch.randint(3, 10, (1,)).long().item())
     )
     feats = tuple(torch.randn(x, 5) for x in feat_sizes)
     if include_ali:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -208,7 +208,7 @@ def test_spect_data_set_validity(temp_dir):
     (
         [1, 2, 3, 4],
         None,
-        torch.LongTensor([[1, -1, -1], [2, -1, -1], [3, -1, -1], [4, -1, -1]])
+        torch.LongTensor([[1, -1, -1], [2, -1, -1], [3, -1, -1], [4, -1, -1]]),
     ),
     (
         [1, ('a', 4, 10), 'a', 3],
@@ -222,6 +222,28 @@ def test_transcript_to_token(transcript, token2id, exp):
     transcript = ['foo'] + transcript
     with pytest.raises(Exception):
         data.transcript_to_token(transcript, token2id)
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize('tok,id2token,exp', [
+    (torch.LongTensor(0, 3), None, []),
+    (
+        torch.LongTensor([[1, -1, -1], [2, -1, -1], [3, -1, -1], [4, -1, -1]]),
+        None,
+        [1, 2, 3, 4],
+    ),
+    (
+        torch.LongTensor([[1, 3, 4], [3, 4, 5], [2, -1, -1]]),
+        {1: 'a', 2: 'b'},
+        [('a', 3, 4), (3, 4, 5), 'b'],
+    )
+])
+def test_token_to_transcript(tok, id2token, exp):
+    act = data.token_to_transcript(tok, id2token)
+    assert exp == act
+    tok = torch.cat([torch.full((1, 3), -1, dtype=torch.long), tok], 0)
+    with pytest.raises(Exception):
+        data.token_to_transcript(tok, id2token)
 
 
 @pytest.mark.cpu

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -225,6 +225,7 @@ nothing should go wrong (b)
 here is an { example /with} some alternates (a)
 } and /here/ is {something really / {really}} (stupid) { ignore this (b)
 (c)
+a11 (d)
 ''')
     trn.seek(0)
     act = data.read_trn(trn, warn=False)
@@ -238,6 +239,7 @@ here is an { example /with} some alternates (a)
             '(stupid)'
         ]),
         ('c', []),
+        ('d', ['a11'])
     ]
 
 
@@ -261,12 +263,14 @@ should get right no prob (b)
             ([['complexity', [['can']]], ['also', 'be']], 10, 4),
             'handled']),
         ('d', []),
+        ('e', ['a11']),
     ]
     data.write_trn(transcripts, trn)
     trn.seek(0)
     assert '''\
 unnecessary { complexity { can } / also be } handled ( c )
 (d)
+a11 (e)
 ''' == trn.read()
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -5,7 +5,11 @@ from __future__ import print_function
 import os
 
 from itertools import repeat, chain
-from io import StringIO
+try:
+    # we want to write string literals in 2.7, not unicode
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 import pytest
 import torch
@@ -206,7 +210,7 @@ def test_spect_data_set_validity(temp_dir):
 @pytest.mark.cpu
 def test_read_trn():
     trn = StringIO()
-    trn.write(u'''\
+    trn.write('''\
 here is a simple example (a)
 nothing should go wrong (b)
 ''')
@@ -217,7 +221,7 @@ nothing should go wrong (b)
         ('b', ['nothing', 'should', 'go', 'wrong']),
     ]
     trn.seek(0)
-    trn.write(u'''\
+    trn.write('''\
 here is an { example /with} some alternates (a)
 } and /here/ is {something really / {really}} (stupid) { ignore this (b)
 (c)
@@ -246,7 +250,7 @@ def test_write_trn():
     ]
     data.write_trn(transcripts, trn)
     trn.seek(0)
-    assert u'''\
+    assert '''\
 again a simple example (a)
 should get right no prob (b)
 ''' == trn.read()
@@ -260,7 +264,7 @@ should get right no prob (b)
     ]
     data.write_trn(transcripts, trn)
     trn.seek(0)
-    assert u'''\
+    assert '''\
 unnecessary { complexity { can } / also be } handled ( c )
 (d)
 ''' == trn.read()


### PR DESCRIPTION
pydrobert.torch.data is almost an entirely new beast.

- SingleContextWindowDataSet has been removed as it was very slow to perform random access over.
- UtteranceContextWindowDataSet has now been renamed ContextWindowDataSet. There are a number of similar naming changes
- SpectDataSet has its own DataLoaders now. The targets can either be alignments or token sequences
- There are a number of utilities for converting between token sequences and sclite, as well as command line hooks
- Some more info has been added to the spect-data-dir-info command to reflect the addition of token directories
- Miscellaneous bug fixes

Don't expect your old code to work with this