### PR TITLE
Torch 1.2.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - pip install scipy pytest
 
 script:
-  - python setup.py test --addopts="-m cpu"
+  - python setup.py test --addopts="-m cpu -x"
 
 branches:
   except:

--- a/pydrobert/torch/estimators.py
+++ b/pydrobert/torch/estimators.py
@@ -31,6 +31,11 @@ import warnings
 
 import torch
 
+try:
+    torch_bool = torch.bool
+except AttributeError:
+    torch_bool = torch.uint8
+
 __author__ = "Sean Robertson"
 __email__ = "sdrobert@cs.toronto.edu"
 __license__ = "Apache 2.0"
@@ -369,8 +374,8 @@ def _to_z_tilde(logits, b, dist):
     elif dist in CATEGORICAL_SYNONYMS:
         b = b.long()
         theta = torch.softmax(logits, dim=-1)
-        mask = torch.zeros_like(logits, dtype=torch.uint8).scatter_(
-            -1, b[..., None], 1)
+        mask = torch.arange(logits.shape[-1], device=b.device)
+        mask = (b.unsqueeze(-1) == mask)
         log_v = v.log()
         z_tilde = torch.where(
             mask,

--- a/pydrobert/torch/training.py
+++ b/pydrobert/torch/training.py
@@ -570,6 +570,9 @@ class TrainingStateController(object):
     state_dir : str, optional
         A path to a directory to store/load model and optimizer states. If
         unset, the information will not be stored/loaded
+    warn : bool, optional
+        Whether to warn using :mod:`warnings` module when a format string does
+        not contain the "epoch" field
 
     Attributes
     ----------
@@ -581,16 +584,19 @@ class TrainingStateController(object):
         up-to-date with `state_csv_path` unless :func:`update_cache` is called
     '''
 
-    def __init__(self, params, state_csv_path=None, state_dir=None):
+    def __init__(self, params, state_csv_path=None, state_dir=None, warn=True):
         super(TrainingStateController, self).__init__()
         self.params = params
-        for s in (
-                self.params.saved_model_fmt, self.params.saved_optimizer_fmt):
-            if not any(x[1] == 'epoch' for x in Formatter().parse(s)):
-                warnings.warn(
-                    'State format string "{}" does not contain "epoch" field, '
-                    'so is possibly not unique. In this case, only the state '
-                    'of the last epoch will persist'.format(s))
+        if warn:
+            for s in (
+                    self.params.saved_model_fmt,
+                    self.params.saved_optimizer_fmt):
+                if not any(x[1] == 'epoch' for x in Formatter().parse(s)):
+                    warnings.warn(
+                        'State format string "{}" does not contain "epoch" '
+                        'field, so is possibly not unique. In this case, only '
+                        'the state of the last epoch will persist. To '
+                        'suppress this warning, set warn=False'.format(s))
         self.state_csv_path = state_csv_path
         self.state_dir = state_dir
         self.cache_hist = dict()

--- a/pydrobert/torch/util.py
+++ b/pydrobert/torch/util.py
@@ -207,7 +207,7 @@ def beam_search_advance(
                 )
             )
         eos_mask = y_prev[-1].eq(eos)
-        num_done = eos_mask.sum(1)
+        num_done = eos_mask.long().sum(1)
         if num_done.sum().item():
             if old_width < width and torch.any(num_done == old_width):
                 raise ValueError(
@@ -823,11 +823,13 @@ def _levenshtein(
     zero = torch.tensor(0., device=device)
     batch_range = torch.arange(batch_size, device=device)
     if return_mask:
+        # this dtype business is a workaround for different default mask
+        # types < 1.2.0 and > 1.2.0
         mask = torch.empty(
             (
                 max_hyp_steps + (0 if exclude_last else 1),
                 max_ref_steps, batch_size),
-            device=device, dtype=torch.uint8)
+            device=device, dtype=ins_cost.eq(ins_cost).dtype)
         mask[0, 0] = 1
         mask[0, 1:] = 0
     elif return_prf_dsts:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,7 @@ test:
     - torch-token-data-dir-to-ctm --help
     - torch-token-data-dir-to-trn --help
     - trn-to-torch-token-data-dir --help
-    - pytest
+    - pytest -x
 
 about:
   home: https://github.com/sdrobert/pydrobert-pytorch

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -184,7 +184,7 @@ def test_convergence(markov, num_latents, device, dist, num_cat, est):
         latents = torch.rand(num_latents, num_cat).to(device)
         latents /= latents.sum(-1, keepdim=True)
         mask = torch.zeros_like(latents).scatter_(
-            -1, latents.argmax(-1, keepdim=True), 1.).byte()
+            -1, latents.argmax(-1, keepdim=True), 1.).eq(1)
         logits = torch.randn(
             num_latents, num_cat, requires_grad=True, device=device)
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -42,14 +42,8 @@ def test_global_soft_attention(device, dim):
     key_size = key_shape[-1]
     arange_shape = [1] * (num_dim - 1)
     arange_shape[dim] = T
-    mask = torch.where(
-        (
-            torch.arange(T, device=device).view(*arange_shape) <
-            key_lens.unsqueeze(dim)
-        ),
-        torch.tensor(1, device=device, dtype=torch.uint8),
-        torch.tensor(0, device=device, dtype=torch.uint8),
-    )
+    mask = torch.arange(T, device=device).view(*arange_shape)
+    mask = mask < key_lens.unsqueeze(dim)
     key.requires_grad_(True)
     first_attention = FirstIsBest(query_size, key_size, dim).to(device)
     equal_attention = ILoveEveryoneEqually(
@@ -141,7 +135,7 @@ def test_dot_product_soft_attention_on_transformer_input():
     assert torch.allclose(g_q1, g_q2, atol=1e-5)
     assert torch.allclose(g_k1, g_k2, atol=1e-5)
     assert torch.allclose(g_v1, g_v2, atol=1e-5)
-    mask = torch.randint(2, (num_batch, len_q, len_k), dtype=torch.uint8)
+    mask = torch.randint(2, (num_batch, len_q, len_k)).eq(1)
     out1 = matrix_attention(query, key, value, mask)
     out2 = our_attention(
         query, key.unsqueeze(2), value.unsqueeze(2),

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -175,7 +175,8 @@ def test_controller_best(temp_dir):
         training.TrainingStateParams(
             saved_model_fmt='model.pt',
         ),
-        state_dir=temp_dir
+        state_dir=temp_dir,
+        warn=False
     )
     model_1.reset_parameters()
     model_2.reset_parameters()


### PR DESCRIPTION
Getting rid of explicit mentions to torch.uint8 when dealing with masks. For backwards compatibility, I just initialize in sneaky ways.