### PR TITLE
Simplify MinimumErrorRate + add utilities

### DIFF
--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -194,77 +194,39 @@ def test_controller_best(temp_dir):
 
 
 @pytest.mark.parametrize('batch_first', [True, False])
-@pytest.mark.parametrize('eos', [None, 0])
-@pytest.mark.parametrize('ref_steps_times', [1, 2])
 @pytest.mark.parametrize('sub_avg', [True, False])
 @pytest.mark.parametrize('reduction', ['mean', 'none'])
-def test_minimum_error_rate_loss(
-        device, batch_first, eos, ref_steps_times, sub_avg, reduction):
+def test_minimum_error_rate_loss(device, batch_first, sub_avg, reduction):
     torch.manual_seed(100)
-    num_batches, num_paths, max_steps, num_classes = 5, 5, 30, 20
-    hyp_lens = torch.randint(1, max_steps + 1, (num_batches, num_paths))
-    ref_lens = torch.randint(
-        1, ref_steps_times * max_steps + 1,
-        hyp_lens.shape
-    )
-    ref = torch.nn.utils.rnn.pad_sequence(
-        [
-            torch.randint(1, num_classes, (x,))
-            for x in ref_lens.flatten()
-        ],
-        padding_value=-1
-    ).view(-1, num_batches, num_paths)
-    hyp = torch.nn.utils.rnn.pad_sequence(
-        [
-            torch.randint(1, num_classes, (x,))
-            for x in hyp_lens.flatten()
-        ],
-        padding_value=num_classes - 1,
-    ).view(-1, num_batches, num_paths)
-    assert hyp_lens.max() == hyp.shape[0]
-    if eos is not None:
-        for i in range(num_batches):
-            for j in range(num_paths):
-                ref[ref_lens[i, j] - 1, i, j] = eos
-                hyp[hyp_lens[i, j] - 1, i, j] = eos
+    num_batches, samples, num_classes = 5, 5, 30
+    max_ref_steps, max_hyp_steps = 10, 5
+    assert max_ref_steps > max_hyp_steps  # nonzero loss guaranteed
     if batch_first:
-        ref = ref.view(-1, num_batches * num_paths)
-        ref = ref.t().view(num_batches, num_paths, -1).contiguous()
-        hyp = hyp.view(-1, num_batches * num_paths)
-        hyp = hyp.t().view(num_batches, num_paths, -1).contiguous()
-        logits = torch.rand(
-            num_batches, num_paths, hyp_lens.max(), num_classes)
+        hyp = torch.randint(
+            num_classes, (num_batches, samples, max_hyp_steps), device=device)
+        hyp[..., 0] = 0
+        ref = torch.randint(
+            num_classes, (num_batches, samples, max_ref_steps), device=device)
+        ref[..., 0] = 0
     else:
-        logits = torch.rand(
-            hyp_lens.max(), num_batches, num_paths, num_classes)
-    ref, hyp, logits = ref.to(device), hyp.to(device), logits.to(device)
-    dist = torch.nn.functional.log_softmax(logits, 3)
-    logits_on_paths = dist.gather(3, hyp.unsqueeze(3)).squeeze(3)
-    log_probs = logits_on_paths.sum(2 if batch_first else 0)
+        hyp = torch.randint(
+            num_classes, (max_hyp_steps, num_batches, samples), device=device)
+        hyp[0] = 0
+        ref = torch.randint(
+            num_classes, (max_ref_steps, num_batches, samples), device=device)
+        ref[0] = 0
+    log_probs = torch.randn(num_batches, samples, device=device)
     loss = training.MinimumErrorRateLoss(
-        eos=eos, sub_avg=sub_avg, batch_first=batch_first, ignore_index=-1,
-        reduction=reduction, lmb=0.
+        eos=None, sub_avg=sub_avg, batch_first=batch_first,
+        reduction=reduction,
     )
-    l1 = loss(logits, ref, hyp)
-    l2 = loss(logits, ref, hyp)
+    l1 = loss(log_probs, ref, hyp)
+    assert l1.ne(0.).any()
+    l2 = loss(log_probs, ref, hyp)
     assert torch.allclose(l1, l2)
-    loss.lmb = 1.
-    log_probs.requires_grad_(True)
-    logits.requires_grad_(True)
+    loss.eos = 0
     l3 = loss(log_probs, ref, hyp)
-    assert torch.allclose(l2, l3)
-    d_log_probs_1, = torch.autograd.grad(
-        [l3], [log_probs], grad_outputs=torch.ones_like(l3))
-    l4 = loss(logits, ref, hyp, log_probs)
-    assert not torch.allclose(l3, l4)
-    d_logits_1, d_log_probs_2 = torch.autograd.grad(
-        [l4], [logits, log_probs], grad_outputs=torch.ones_like(l4))
-    assert torch.allclose(d_log_probs_1, d_log_probs_2)
-    l5 = loss(logits, ref, hyp)
-    assert torch.allclose(l4, l5)
-    d_logits_2, = torch.autograd.grad(
-        [l5], [logits], grad_outputs=torch.ones_like(l5))
-    assert not torch.allclose(d_logits_1, d_logits_2)
+    assert l3.eq(0.).all()
 
 
 @pytest.mark.parametrize('batch_first', [True, False])


### PR DESCRIPTION
pydrobert.torch.training.MinimumErrorRate had a cross-entropy term built in to the loss, which complicated its interface. Now the user can use pydrobert.torch.util.sequence_log_probs to extract log probabilities from logits, making it easy to build a cross-entropy term from logits.