### PR TITLE
Retailored some aspects of data loaders + data params

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -539,22 +539,29 @@ def test_spect_seq_to_batch(include_ali, include_ref, batch_first):
 
 @pytest.mark.cpu
 @pytest.mark.parametrize('eos', [None, -1])
-def test_spect_training_data_loader(temp_dir, populate_torch_dir, eos):
+@pytest.mark.parametrize('split_params', [True, False])
+def test_spect_training_data_loader(
+        temp_dir, populate_torch_dir, eos, split_params):
     torch.manual_seed(40)
     num_utts, batch_size, num_filts = 20, 5, 11
     populate_torch_dir(temp_dir, num_utts, num_filts=num_filts)
-    p = data.SpectDataSetParams(
-        batch_size=batch_size,
-        seed=2,
-        eos=eos,
-    )
+    if split_params:
+        params = data.DataSetParams(batch_size=batch_size, seed=2)
+        data_params = data.SpectDataParams(eos=eos)
+    else:
+        params = data.SpectDataSetParams(
+            batch_size=batch_size, seed=2, eos=eos)
+        data_params = None
     # check missing either ali or ref gives None in batches
-    data_loader = data.SpectTrainingDataLoader(temp_dir, p, ali_subdir=None)
+    data_loader = data.SpectTrainingDataLoader(
+        temp_dir, params, data_params=data_params, ali_subdir=None)
     assert next(iter(data_loader))[1] is None
-    data_loader = data.SpectTrainingDataLoader(temp_dir, p, ref_subdir=None)
+    data_loader = data.SpectTrainingDataLoader(
+        temp_dir, params, data_params=data_params, ref_subdir=None)
     assert next(iter(data_loader))[2] is None
     assert next(iter(data_loader))[4] is None
-    data_loader = data.SpectTrainingDataLoader(temp_dir, p)
+    data_loader = data.SpectTrainingDataLoader(
+        temp_dir, params, data_params=data_params)
 
     def _get_epoch(sort):
         ep_feats, ep_ali, ep_ref = [], [], []
@@ -624,7 +631,8 @@ def test_spect_training_data_loader(temp_dir, populate_torch_dir, eos):
     _compare_epochs(_get_epoch(True), _get_epoch(True), True)
     data_loader.epoch = 1
     _compare_epochs(ep1, _get_epoch(False), True)
-    data_loader = data.SpectTrainingDataLoader(temp_dir, p, num_workers=4)
+    data_loader = data.SpectTrainingDataLoader(
+        temp_dir, params, data_params=data_params, num_workers=4)
     _compare_epochs(ep0, _get_epoch(False), True)
     _compare_epochs(ep1, _get_epoch(False), True)
     data_loader.batch_first = False
@@ -635,13 +643,21 @@ def test_spect_training_data_loader(temp_dir, populate_torch_dir, eos):
 
 @pytest.mark.cpu
 @pytest.mark.parametrize('eos', [None, -1])
-def test_spect_evaluation_data_loader(temp_dir, populate_torch_dir, eos):
+@pytest.mark.parametrize('split_params', [True, False])
+def test_spect_evaluation_data_loader(
+        temp_dir, populate_torch_dir, eos, split_params):
     torch.manual_seed(41)
     feat_dir = os.path.join(temp_dir, 'feat')
     ali_dir = os.path.join(temp_dir, 'ali')
     os.makedirs(feat_dir)
     os.makedirs(ali_dir)
-    p = data.SpectDataSetParams(batch_size=5, eos=eos)
+    batch_size = 5
+    if split_params:
+        params = data.DataSetParams(batch_size=batch_size)
+        data_params = data.SpectDataParams(eos=eos)
+    else:
+        params = data.SpectDataSetParams(batch_size=batch_size, eos=eos)
+        data_params = None
     feats, ali, ref, feat_sizes, ref_sizes, utt_ids = populate_torch_dir(
         temp_dir, 20)
     if eos is not None:
@@ -652,10 +668,12 @@ def test_spect_evaluation_data_loader(temp_dir, populate_torch_dir, eos):
         ref_sizes = [x + 1 for x in ref_sizes]
     # check that ali and ref can be missing
     data_loader = data.SpectEvaluationDataLoader(
-        temp_dir, p, ali_subdir=None, ref_subdir=None)
+        temp_dir, params, data_params=data_params, ali_subdir=None,
+        ref_subdir=None)
     assert next(iter(data_loader))[1:3] == (None, None)
     assert next(iter(data_loader))[4] is None
-    data_loader = data.SpectEvaluationDataLoader(temp_dir, p)
+    data_loader = data.SpectEvaluationDataLoader(
+        temp_dir, params, data_params=data_params)
 
     def _compare_data_loader():
         batch_first = data_loader.batch_first
@@ -701,23 +719,29 @@ def test_spect_evaluation_data_loader(temp_dir, populate_torch_dir, eos):
 
     _compare_data_loader()
     _compare_data_loader()  # order should not change
-    data_loader = data.SpectEvaluationDataLoader(temp_dir, p, num_workers=4)
+    data_loader = data.SpectEvaluationDataLoader(
+        temp_dir, params, data_params=data_params, num_workers=4)
     _compare_data_loader()  # order should still not change
     data_loader.batch_first = False
     _compare_data_loader()
 
 
 @pytest.mark.cpu
-def test_window_training_data_loader(temp_dir, populate_torch_dir):
+@pytest.mark.parametrize('split_params', [True, False])
+def test_window_training_data_loader(
+        temp_dir, populate_torch_dir, split_params):
     populate_torch_dir(temp_dir, 5, num_filts=2)
-    p = data.ContextWindowDataSetParams(
-        context_left=1,
-        context_right=1,
-        batch_size=5,
-        seed=2,
-        drop_last=True,
-    )
-    data_loader = data.ContextWindowTrainingDataLoader(temp_dir, p)
+    if split_params:
+        params = data.DataSetParams(batch_size=5, seed=2, drop_last=True)
+        data_params = data.ContextWindowDataParams(
+            context_left=1, context_right=1)
+    else:
+        params = data.ContextWindowDataSetParams(
+            context_left=1, context_right=1, batch_size=5, seed=2,
+            drop_last=True)
+        data_params = None
+    data_loader = data.ContextWindowTrainingDataLoader(
+        temp_dir, params, data_params=data_params)
     total_windows_ep0 = 0
     for feat, ali in data_loader:
         windows = feat.shape[0]
@@ -736,10 +760,7 @@ def test_window_training_data_loader(temp_dir, populate_torch_dir):
         total_windows_ep1 += windows
     assert total_windows_ep0 == total_windows_ep1
     data_loader = data.ContextWindowTrainingDataLoader(
-        temp_dir, p,
-        init_epoch=1,
-        num_workers=4,
-    )
+        temp_dir, params, init_epoch=1, data_params=data_params, num_workers=4)
     feats_ep1_b, alis_ep1_b = [], []
     for feats, alis in data_loader:
         feats_ep1_b.append(feats)
@@ -749,7 +770,7 @@ def test_window_training_data_loader(temp_dir, populate_torch_dir):
         for (feats_a, feats_b) in zip(feats_ep1_a, feats_ep1_b)
     )
     assert all(
-        torch.allclose(alis_a.float(), alis_b.float())
+        torch.all(alis_a == alis_b)
         for (alis_a, alis_b) in zip(alis_ep1_a, alis_ep1_b)
     )
     data_loader.epoch = 1
@@ -762,23 +783,28 @@ def test_window_training_data_loader(temp_dir, populate_torch_dir):
         for (feats_a, feats_c) in zip(feats_ep1_a, feats_ep1_c)
     )
     assert all(
-        torch.allclose(alis_a.float(), alis_c.float())
+        torch.all(alis_a == alis_c)
         for (alis_a, alis_c) in zip(alis_ep1_a, alis_ep1_c)
     )
 
 
 @pytest.mark.cpu
-def test_window_evaluation_data_loader(temp_dir, populate_torch_dir):
+@pytest.mark.parametrize('split_params', [True, False])
+def test_window_evaluation_data_loader(
+        temp_dir, populate_torch_dir, split_params):
     torch.manual_seed(1)
     feat_dir = os.path.join(temp_dir, 'feat')
     ali_dir = os.path.join(temp_dir, 'ali')
     os.makedirs(feat_dir)
     os.makedirs(ali_dir)
-    p = data.ContextWindowDataSetParams(
-        context_left=1,
-        context_right=1,
-        batch_size=5,
-    )
+    if split_params:
+        params = data.DataSetParams(batch_size=5)
+        data_params = data.ContextWindowDataParams(
+            context_left=1, context_right=1)
+    else:
+        params = data.ContextWindowDataSetParams(
+            context_left=1, context_right=1, batch_size=5)
+        data_params = None
     feats, alis, _, feat_sizes, _, utt_ids = populate_torch_dir(
         temp_dir, 20, include_ref=False)
 
@@ -795,14 +821,15 @@ def test_window_evaluation_data_loader(temp_dir, populate_torch_dir):
                 b_alis == torch.cat(alis[cur_idx:cur_idx + 5]))
             cur_idx += 5
     data_loader = data.ContextWindowEvaluationDataLoader(
-        temp_dir, p, ali_subdir=None)
+        temp_dir, params, data_params=data_params, ali_subdir=None)
     # check batching works when alignments are empty
     assert next(iter(data_loader))[1] is None
-    data_loader = data.ContextWindowEvaluationDataLoader(temp_dir, p)
+    data_loader = data.ContextWindowEvaluationDataLoader(
+        temp_dir, params, data_params=data_params)
     _compare_data_loader(data_loader)
     _compare_data_loader(data_loader)  # order should not change
     data_loader = data.ContextWindowEvaluationDataLoader(
-        temp_dir, p, num_workers=4)
+        temp_dir, params, data_params=data_params, num_workers=4)
     _compare_data_loader(data_loader)  # order should still not change
 
 


### PR DESCRIPTION
The idea behind this PR was to increase separation between data set and data parameters in order to make it easier to clump together training vs validation parameters.

All data loaders in pydrobert.torch.data can either load one parameter object as before (where all parameters are assumed to be in that object), or two: one that handles data set parameters, and one that handles data parameters.

DataSetParams no longer has a "seed" parameter. Instead, seeds can be passed as keyword arguments to training data loaders. Alternatively, if the `params` instance happens to have a "seed" attribute (e.g. by subclasssing DataSetParams), that seed will be used.