### PR TITLE
Optuna hook redesign for pydrobert.param.optuna

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 install:
   - pip install -U pip setuptools setuptools_scm
   - pip install -r requirements.txt
-  - pip install scipy pytest optuna
+  - pip install scipy pytest pydrobert-param optuna
 
 script:
   - python setup.py test --addopts="-m cpu -x"

--- a/pydrobert/torch/training.py
+++ b/pydrobert/torch/training.py
@@ -499,46 +499,20 @@ class TrainingStateParams(param.Parameterized):
         'string (see TrainingStateController)'
     )
 
+    _tunable = (
+        'num_epochs', 'log10_learning_rate',
+        'early_stopping_threshold', 'early_stopping_patience',
+        'early_stopping_burnin', 'reduce_lr_threshold',
+        'reduce_lr_patience', 'reduce_lr_cooldown',
+    )
+
+    def get_tunable(cls):
+        return set(cls._tunable)
+
     @classmethod
-    def build_from_optuna_trial(cls, trial, base=None, only=None):
-        '''Build a TrainingStateParams by sampling from an Optuna trial
-
-        `Optuna <https://optuna.org/>`__ is a define-by-run hyperparameter
-        optimization framework. This class method constructs a
-        :class:`TrainingStateParams` instance with parameter values sampled
-        using `trial`. The folling parameter values can be sampled
-
-        - num_epochs
-        - log10_learning_rate
-        - early_stopping_threshold
-        - early_stopping_patience
-        - early_stopping_burnin
-        - reduce_lr_threshold
-        - reduce_lr_patience
-        - reduce_lr_cooldown
-
-        Parameters
-        ----------
-        trial : optuna.trial.Trial
-        base : TrainingStateParams or None, optional
-            If set, parameter values will be loaded into this instance. If
-            unset, a new instance will be created
-        only : collection or None, optional
-            Only sample parameters with names in this set. If :obj:`None`,
-            all the above will be sampled
-
-        Returns
-        -------
-        params : TrainingStateController
-            Sampled parameter values are populated in `params`
-        '''
+    def suggest_params(cls, trial, base=None, only=None, prefix=''):
         if only is None:
-            only = {
-                'num_epochs', 'log10_learning_rate',
-                'early_stopping_threshold', 'early_stopping_patience',
-                'early_stopping_burnin', 'reduce_lr_threshold',
-                'reduce_lr_patience', 'reduce_lr_cooldown',
-            }
+            only = cls.get_tunable()
         params = cls() if base is None else base
         pdict = params.params()
         eps = torch.finfo(torch.float).eps
@@ -548,10 +522,10 @@ class TrainingStateParams(param.Parameterized):
                 continue
             softbounds = pp.get_soft_bounds()
             if isinstance(pp, param.Integer):
-                val = trial.suggest_int(name, *softbounds)
+                val = trial.suggest_int(prefix + name, *softbounds)
             else:
                 softbounds = softbounds[0] + eps, softbounds[1]
-                val = trial.suggest_uniform(name, *softbounds)
+                val = trial.suggest_uniform(prefix + name, *softbounds)
             setattr(params, name, val)
         return params
 

--- a/pydrobert/torch/training.py
+++ b/pydrobert/torch/training.py
@@ -413,7 +413,11 @@ class MinimumErrorRateLoss(torch.nn.Module):
 
 
 class TrainingStateParams(param.Parameterized):
-    '''Parameters controlling a TrainingStateController'''
+    '''Parameters controlling a TrainingStateController
+
+    This class implements the
+    :class:`pydrobert.param.optuna.TunableParameterized` interface
+    '''
     num_epochs = param.Integer(
         None, bounds=(1, None), softbounds=(10, 100),
         doc='Total number of epochs to run for. If unspecified, runs '

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   run:
     - python
     - numpy
-    - pytorch
+    - pytorch>= 1.0.1
     - future
     - param
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 future
 numpy
-torch
+torch>=1.0.1
 param

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def main():
         ],
         setup_requires=SETUP_REQUIRES,
         tests_require=[
-            'pytest', 'scipy', 'optuna',
+            'pytest', 'scipy',
         ],
         entry_points={
             'console_scripts': [

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -4,8 +4,6 @@ from __future__ import print_function
 
 import os
 
-from unittest.mock import MagicMock
-
 import torch
 import pytest
 import pydrobert.torch.training as training

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -4,10 +4,11 @@ from __future__ import print_function
 
 import os
 
+from unittest.mock import MagicMock
+
 import torch
 import pytest
 import pydrobert.torch.training as training
-
 
 __author__ = "Sean Robertson"
 __email__ = "sdrobert@cs.toronto.edu"
@@ -343,16 +344,20 @@ def test_hard_optimal_completion_distillation_loss(
 
 
 @pytest.mark.cpu
-def test_training_state_params_build_from_optuna_trial():
-    optuna = pytest.importorskip('optuna')  # conda doesn't have it
-    low = training.TrainingStateParams.params()['num_epochs'].softbounds[0]
+def test_pydrobert_param_optuna_hooks():
+    poptuna = pytest.importorskip('pydrobert.param.optuna')
+    optuna = pytest.importorskip('optuna')
+    assert issubclass(
+        training.TrainingStateParams, poptuna.TunableParameterized)
+    global_dict = {'training': training.TrainingStateParams()}
+    assert 'training.log10_learning_rate' in poptuna.get_param_dict_tunable(
+        global_dict)
 
     def objective(trial):
-        params = training.TrainingStateParams.build_from_optuna_trial(
-            trial, only={'num_epochs', 'log10_learning_rate', 'ignore_me'})
-        return params.num_epochs ** 2
+        param_dict = poptuna.suggest_param_dict(trial, global_dict)
+        return param_dict['training'].log10_learning_rate
 
-    sampler = optuna.samplers.TPESampler(seed=10)
+    sampler = optuna.samplers.RandomSampler(seed=5)
     study = optuna.create_study(sampler=sampler)
-    study.optimize(objective, n_trials=30)
-    assert study.best_params['num_epochs'] == low
+    study.optimize(objective, n_trials=50)
+    assert study.best_params['training.log10_learning_rate'] < -5


### PR DESCRIPTION
In the next release of pydrobert-param (0.2.0), I'll be rolling out a general interface between param.Parameterized and optuna. This PR makes pydrobert.pytorch param.Parameterized objects compatible with the interface, insofar as they have any parameters to optimize.