### PR TITLE
Updates to TrainingStateController, including semantics bug fix

### DIFF
--- a/pydrobert/torch/training.py
+++ b/pydrobert/torch/training.py
@@ -608,8 +608,8 @@ class TrainingStateController(object):
     ...    params,
     ...    state_csv_path='log.csv',
     ...    state_dir='states')
-    >>> controller.load_model_and_optimizer_for_epoch(
-    ...     model, optimizer, controller.get_last_epoch())  # load previous
+    >>> # load previous
+    >>> controller.load_model_and_optimizer_for_epoch(model, optimizer)
     >>> for epoch in range(params.num_epochs):
     >>>     # do training loop for epoch
     >>>     train_loss, val_loss = 0.1, 0.01
@@ -800,13 +800,22 @@ class TrainingStateController(object):
                 min_met = info[ent]
         return min_epoch
 
-    def load_model_and_optimizer_for_epoch(self, model, optimizer, epoch=0):
+    def load_model_and_optimizer_for_epoch(self, model, optimizer, epoch=None):
         '''Load up model and optimizer states, or initialize them
 
-        If `epoch` is 0, the model and optimizer are initialized with states
-        for the beginning of the experiment. Otherwise, we look for
-        appropriately named files in ``self.state_dir``
+        Parameters
+        ----------
+        model : torch.nn.Module
+        optimizer : torch.optim.Optimizer
+        epoch : int or :obj:`None`, optional
+            The epoch from which the states should be loaded. We look for the
+            appropriately named files in ``self.state_dir``. If `epoch` is
+            :obj:`None`, the last epoch in recorded history will be loaded. If
+            it's 0, the model and optimizer are initialized with states
+            for the beginning of the experiment.
         '''
+        if epoch is None:
+            epoch = self.get_last_epoch()
         if not epoch:
             if self.params.seed is not None:
                 torch.manual_seed(self.params.seed)

--- a/pydrobert/torch/training.py
+++ b/pydrobert/torch/training.py
@@ -800,7 +800,7 @@ class TrainingStateController(object):
                 min_met = info[ent]
         return min_epoch
 
-    def load_model_for_epoch(self, model, epoch=None):
+    def load_model_for_epoch(self, model, epoch=None, strict=True):
         '''Load up just the model, or initialize it
 
         Parameters
@@ -813,6 +813,9 @@ class TrainingStateController(object):
             :obj:`None`, the best epoch in recorded history will be loaded. If
             it's 0, the model is initialized with states from the beginning of
             the experiment
+        strict : bool, optional
+            Whether to strictly enforce that the keys in ``model.state_dict()``
+            match those that were saved
         '''
         if epoch is None:
             epoch = self.get_best_epoch()
@@ -833,14 +836,15 @@ class TrainingStateController(object):
                 os.path.join(self.state_dir, model_basename),
                 map_location='cpu',
             )
-            model.load_state_dict(model_state_dict)
+            model.load_state_dict(model_state_dict, strict=strict)
         else:
             warnings.warn(
                 'Unable to load model for epoch {}. No state directory!'
                 ''.format(epoch)
             )
 
-    def load_model_and_optimizer_for_epoch(self, model, optimizer, epoch=None):
+    def load_model_and_optimizer_for_epoch(
+            self, model, optimizer, epoch=None, strict=True):
         '''Load up model and optimizer states, or initialize them
 
         Parameters
@@ -855,6 +859,9 @@ class TrainingStateController(object):
             :obj:`None`, the last epoch in recorded history will be loaded. If
             it's 0, the model and optimizer are initialized with states
             for the beginning of the experiment.
+        strict : bool, optional
+            Whether to strictly enforce that the keys in ``model.state_dict()``
+            match those that were saved
         '''
         if epoch is None:
             epoch = self.get_last_epoch()
@@ -881,7 +888,7 @@ class TrainingStateController(object):
                 os.path.join(self.state_dir, model_basename),
                 map_location='cpu',
             )
-            model.load_state_dict(model_state_dict)
+            model.load_state_dict(model_state_dict, strict=strict)
             optimizer_state_dict = torch.load(
                 os.path.join(self.state_dir, optimizer_basename),
                 map_location='cpu',

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -199,6 +199,7 @@ def test_controller_best(temp_dir):
     optimizer_2 = torch.optim.Adam(model_2.parameters(), lr=2)
     model_3 = torch.nn.Linear(100, 100)
     optimizer_3 = torch.optim.Adam(model_1.parameters(), lr=3)
+    training.TrainingStateController.SCIENTIFIC_PRECISION = 5
     controller = training.TrainingStateController(
         training.TrainingStateParams(), state_dir=temp_dir)
     assert controller.get_best_epoch() == 0
@@ -222,7 +223,8 @@ def test_controller_best(temp_dir):
     assert optimizer_3.param_groups[0]['lr'] == 2
     controller.update_for_epoch(model_1, optimizer_1, .6, .6)
     assert controller.get_best_epoch() == 1
-    controller.update_for_epoch(model_1, optimizer_1, .4, .4)
+    # round-on-even dictates .400005 will round to .40000
+    controller.update_for_epoch(model_1, optimizer_1, .400005, .400005)
     assert controller.get_best_epoch() == 5
     controller.load_model_and_optimizer_for_epoch(model_3, optimizer_3, 5)
     for parameter_1, parameter_3 in zip(
@@ -231,6 +233,14 @@ def test_controller_best(temp_dir):
     with pytest.raises(IOError):
         # no longer the best
         controller.load_model_and_optimizer_for_epoch(model_3, optimizer_3, 1)
+    # this block ensures that negligible differences in the loss aren't being
+    # considered "better." This is necessary to remain consistent
+    # with the truncated floats saved to history
+    controller.update_for_epoch(model_1, optimizer_1, .4, .4)
+    # last
+    controller.load_model_and_optimizer_for_epoch(model_3, optimizer_3, 6)
+    # best (because ~ equal and older)
+    controller.load_model_and_optimizer_for_epoch(model_3, optimizer_3, 5)
     # ensure we're keeping track of the last when the model name is not
     # unique
     controller = training.TrainingStateController(

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -104,6 +104,26 @@ def test_controller_stores_and_retrieves(temp_dir, device):
             model.parameters(), model_2.parameters(), model_3.parameters()):
         assert not torch.allclose(parameter_1, parameter_2)
         assert torch.allclose(parameter_2, parameter_3)
+    torch.manual_seed(300)
+    model_2 = torch.nn.Linear(2, 2).to(device)
+    optimizer_2 = torch.optim.Adam(model_2.parameters())
+    epoch_info['epoch'] = 3
+    epoch_info['val_met'] = 2
+    controller.save_model_and_optimizer_with_info(
+        model_2, optimizer_2, epoch_info)
+    controller.save_info_to_hist(epoch_info)
+    # by default, load_model_and_optimizer_for_epoch loads last
+    controller.load_model_and_optimizer_for_epoch(model_3, optimizer_3)
+    for parameter_1, parameter_2, parameter_3 in zip(
+            model.parameters(), model_2.parameters(), model_3.parameters()):
+        assert torch.allclose(parameter_1, parameter_3)
+        assert not torch.allclose(parameter_2, parameter_3)
+    # by default, load_model_for_epoch loads best
+    controller.load_model_for_epoch(model_3)
+    for parameter_1, parameter_2, parameter_3 in zip(
+            model.parameters(), model_2.parameters(), model_3.parameters()):
+        assert not torch.allclose(parameter_1, parameter_3)
+        assert torch.allclose(parameter_2, parameter_3)
 
 
 @pytest.mark.cpu


### PR DESCRIPTION
I've changed the default epoch of load_model_and_optimizer_for_epoch to be the last epoch. I've also added a method load_model, which just loads the model (the best by default). Comparing epochs to determine the best now has a negligible threshold determined by how it's serialized. There's also a "strict" flag for both load methods in case models differ between train and test time