### PR TITLE
Handling unk/oov in transcripts

### DIFF
--- a/pydrobert/torch/command_line.py
+++ b/pydrobert/torch/command_line.py
@@ -295,8 +295,10 @@ def trn_to_torch_token_data_dir(args=None):
     token2id = _parse_token2id(
         options.token2id, options.swap, options.swap)
     if options.unk_symbol is not None and options.unk_symbol not in token2id:
-        raise ValueError(
-            'Unk symbol "{}" is not in token2id'.format(options.unk_symbol))
+        print(
+            'Unk symbol "{}" is not in token2id'.format(options.unk_symbol),
+            file=sys.stderr)
+        return 1
     transcripts = data.read_trn(options.trn)
     # we manually search for alternates in a first pass, as we don't know what
     # filters users have on warnings
@@ -467,6 +469,10 @@ def _ctm_to_torch_token_data_dir_parse_args(args):
         'format ``<utt_id> <wavefile_name> <channel>``. If neither "--wc2utt" '
         'nor "--utt2wc" has been specied, the wavefile name will be treated '
         'as the utterance ID')
+    parser.add_argument(
+        '--unk-symbol', default=None,
+        help='If set, will map out-of-vocabulary tokens to this symbol'
+    )
     return parser.parse_args(args)
 
 
@@ -528,6 +534,11 @@ def ctm_to_torch_token_data_dir(args=None):
         return ex.code
     token2id = _parse_token2id(
         options.token2id, options.swap, options.swap)
+    if options.unk_symbol is not None and options.unk_symbol not in token2id:
+        print(
+            'Unk symbol "{}" is not in token2id'.format(options.unk_symbol),
+            file=sys.stderr)
+        return 1
     if options.wc2utt:
         wc2utt = _parse_wc2utt(options.wc2utt, False, False)
     elif options.utt2wc:
@@ -537,7 +548,7 @@ def ctm_to_torch_token_data_dir(args=None):
     transcripts = data.read_ctm(options.ctm, wc2utt)
     _save_transcripts_to_dir(
         transcripts, token2id, options.file_prefix, options.file_suffix,
-        options.dir, options.frame_shift_ms)
+        options.dir, options.frame_shift_ms, options.unk_symbol)
     return 0
 
 

--- a/pydrobert/torch/command_line.py
+++ b/pydrobert/torch/command_line.py
@@ -225,6 +225,10 @@ def _trn_to_torch_token_data_dir_parse_args(args):
         '--swap', action='store_true', default=False,
         help='If set, swaps the order of key and value in `token2id`'
     )
+    parser.add_argument(
+        '--unk-symbol', default=None,
+        help='If set, will map out-of-vocabulary tokens to this symbol'
+    )
     return parser.parse_args(args)
 
 
@@ -256,11 +260,12 @@ def _parse_token2id(file, swap, return_swap):
 
 def _save_transcripts_to_dir(
         transcripts, token2id, file_prefix, file_suffix, dir_,
-        frame_shift_ms=None):
+        frame_shift_ms=None, unk=None):
     if not os.path.isdir(dir_):
         os.makedirs(dir_)
     for utt_id, transcript in transcripts:
-        tok = data.transcript_to_token(transcript, token2id, frame_shift_ms)
+        tok = data.transcript_to_token(
+            transcript, token2id, frame_shift_ms, unk)
         path = os.path.join(dir_, file_prefix + utt_id + file_suffix)
         torch.save(tok, path)
 
@@ -289,6 +294,9 @@ def trn_to_torch_token_data_dir(args=None):
         return ex.code
     token2id = _parse_token2id(
         options.token2id, options.swap, options.swap)
+    if options.unk_symbol is not None and options.unk_symbol not in token2id:
+        raise ValueError(
+            'Unk symbol "{}" is not in token2id'.format(options.unk_symbol))
     transcripts = data.read_trn(options.trn)
     # we manually search for alternates in a first pass, as we don't know what
     # filters users have on warnings
@@ -311,7 +319,7 @@ def trn_to_torch_token_data_dir(args=None):
                 old_transcript = x[0]
     _save_transcripts_to_dir(
         transcripts, token2id, options.file_prefix, options.file_suffix,
-        options.dir)
+        options.dir, unk=options.unk_symbol)
     return 0
 
 

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -90,10 +90,13 @@ a b b c (utt1)
 
 d { e / f } g (utt3)
 {{{h / i} / j} / k} (utt4)
+A a (utt5)
 ''')
     with warnings.catch_warnings(record=True):
         assert not command_line.trn_to_torch_token_data_dir(
-            [trn_path, tokens_path, ref_dir, '--alt-handler=first'] +
+            [
+                trn_path, tokens_path, ref_dir,
+                '--alt-handler=first', '--unk-symbol=c'] +
             (['--swap'] if tokens == 'id2token' else [])
         )
     act_utt1 = torch.load(os.path.join(ref_dir, 'utt1.pt'))
@@ -106,6 +109,9 @@ d { e / f } g (utt3)
         [3, -1, -1], [4, -1, -1], [6, -1, -1]]))
     act_utt4 = torch.load(os.path.join(ref_dir, 'utt4.pt'))
     assert torch.all(act_utt4 == torch.tensor([[7, -1, -1]]))
+    act_utt5 = torch.load(os.path.join(ref_dir, 'utt5.pt'))
+    assert torch.all(act_utt5 == torch.tensor([
+        [2, -1, -1], [0, -1, -1]]))
 
 
 @pytest.mark.cpu

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -182,8 +182,10 @@ w_1 A 0.3 1.0 c   ;; ignore this comment
 w_2 A 0.0 0.0 b
 w_3 A 0.0 1000.0 d
 w_3 A 1.0 0.1 d
+w_4 A 0.0 2.0 Z
+w_4 A 0.1 1.1 a
 ''')
-    args = [ctm_path, tokens_path, ref_dir]
+    args = [ctm_path, tokens_path, ref_dir, '--unk-symbol=a']
     if tokens == 'id2token':
         args.append('--swap')
     if channels == 'utt2wc':
@@ -202,6 +204,10 @@ w_3 A 1.0 0.1 d
         os.path.join(ref_dir, 'u_3.pt' if channels else 'w_3.pt'))
     assert torch.all(act_utt3 == torch.tensor([
         [3, 0, 100000], [3, 100, 110]]))
+    act_utt4 = torch.load(
+        os.path.join(ref_dir, 'u_4.pt' if channels else 'w_4.pt'))
+    assert torch.all(act_utt4 == torch.tensor(
+        [[0, 0, 200], [0, 10, 120]]))
 
 
 @pytest.mark.cpu

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -365,21 +365,26 @@ last A 0.0 10.0111 hullo
 
 
 @pytest.mark.cpu
-@pytest.mark.parametrize('transcript,token2id,exp', [
-    ([], None, torch.LongTensor(0, 3)),
+@pytest.mark.parametrize('transcript,token2id,unk,exp', [
+    ([], None, None, torch.LongTensor(0, 3)),
     (
         [1, 2, 3, 4],
-        None,
+        None, None,
         torch.LongTensor([[1, -1, -1], [2, -1, -1], [3, -1, -1], [4, -1, -1]]),
     ),
     (
         [1, ('a', 4, 10), 'a', 3],
-        {'a': 2},
+        {'a': 2}, None,
         torch.LongTensor([[1, -1, -1], [2, 4, 10], [2, -1, -1], [3, -1, -1]]),
     ),
+    (
+        ['foo', 1, 'bar'],
+        {'foo': 0, 'baz': 3}, 'baz',
+        torch.LongTensor([[0, -1, -1], [3, -1, -1], [3, -1, -1]]),
+    ),
 ])
-def test_transcript_to_token(transcript, token2id, exp):
-    act = data.transcript_to_token(transcript, token2id)
+def test_transcript_to_token(transcript, token2id, unk, exp):
+    act = data.transcript_to_token(transcript, token2id, unk=unk)
     assert torch.all(exp == act)
     transcript = ['foo'] + transcript
     with pytest.raises(Exception):


### PR DESCRIPTION
Three primary changes in this PR:

- transcript_to_token now allows for an unk symbol to be passed. Any token not in token2id will be replaced with this
- both trn-to-torch-token-data-dir and ctm-to-torch-token-data-dir now have an --oov-symbol option to access this