### PR TITLE
Better handling of text data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ python:
 install:
   - pip install -U pip setuptools setuptools_scm
   - pip install -r requirements.txt
-  - pip install scipy pytest pydrobert-param optuna
+  - pip install scipy pytest pydrobert-param
+  - pip install optuna || echo "No optuna (py 2.7?)"
 
 script:
   - python setup.py test --addopts="-m cpu -x"

--- a/pydrobert/torch/command_line.py
+++ b/pydrobert/torch/command_line.py
@@ -485,9 +485,9 @@ def _load_transcripts_from_data_dir(
         strip_timing)
     dl = torch.utils.data.DataLoader(
         ds, batch_size=None, num_workers=num_workers)
-    transcripts = list(dl)
+    for x in dl:
+        yield x
     del dl, ds
-    return transcripts
 
 
 def torch_token_data_dir_to_trn(args=None):
@@ -904,12 +904,12 @@ def compute_torch_token_data_dir_error_rates(args=None):
                     'integers'.format(options.ignore.name))
     else:
         ignore = set()
-    ref_transcripts = _load_transcripts_from_data_dir(
+    ref_transcripts = list(_load_transcripts_from_data_dir(
         ref_dir, id2token, options.file_prefix, options.file_suffix,
-        strip_timing=True)
-    hyp_transcripts = _load_transcripts_from_data_dir(
+        strip_timing=True))
+    hyp_transcripts = list(_load_transcripts_from_data_dir(
         hyp_dir, id2token, options.file_prefix, options.file_suffix,
-        strip_timing=True)
+        strip_timing=True))
     idx = 0
     while idx < max(len(ref_transcripts), len(hyp_transcripts)):
         missing_ref = missing_hyp = False

--- a/pydrobert/torch/command_line.py
+++ b/pydrobert/torch/command_line.py
@@ -37,6 +37,7 @@ __all__ = [
     'compute_torch_token_data_dir_error_rates',
     'ctm_to_torch_token_data_dir',
     'get_torch_spect_data_dir_info',
+    'torch_token_data_dir_to_ctm',
     'torch_token_data_dir_to_trn',
     'trn_to_torch_token_data_dir',
 ]
@@ -244,8 +245,7 @@ def _trn_to_torch_token_data_dir_parse_args(args):
         '--skip-frame-times', action='store_true', default=False,
         help='If true, will store token tensors of shape (R,) instead of '
         '(R, 3), foregoing segment start and end times (which trn does not '
-        'have). Useful for BitextDatasets, but cannot be used with '
-        'SpectDatasets'
+        'have).'
     )
     return parser.parse_args(args)
 
@@ -502,8 +502,7 @@ def torch_token_data_dir_to_trn(args=None):
         here is another (utterance_b)
 
     This command scans the contents of a directory like ``ref/`` in a
-    :class:`pydrobert.torch.data.SpectDataSet` or ``src/`` or ``tgt/`` in a
-    :class:`pydrobert.torch.data.BitextDataSet` and converts each such file
+    :class:`pydrobert.torch.data.SpectDataSet` and converts each such file
     into a transcription. Each such transcription is then written to a "trn"
     file. See the command :func:`get_torch_spect_data_dir_info` (command line
     "get-torch-spect-data-dir-info") for more information on a

--- a/pydrobert/torch/data.py
+++ b/pydrobert/torch/data.py
@@ -638,7 +638,7 @@ def read_trn(trn, warn=True, processes=0, chunk_size=1000):
         time an alteration appears in the "trn" file. Alterations appear in
         `transcripts` as elements of ``([[alt_1_word_1, alt_1_word_2, ...],
         [alt_2_word_1, alt_2_word_2, ...], ...], -1, -1)`` so that
-        ``transcript_to_token`` will not attempt to process alterations as
+        :func:`transcript_to_token` will not attempt to process alterations as
         token start and end times
     processes : int, optional
         The number of processes used to parse the lines of the trn file. If

--- a/pydrobert/torch/data.py
+++ b/pydrobert/torch/data.py
@@ -587,8 +587,7 @@ def read_trn_iter(trn, warn=True, processes=0, chunk_size=1000):
         with open(trn) as trn:
             for x in read_trn_iter(trn, warn, processes):
                 yield x  # plz yield from when I remove 2.7 support thank uuuuu
-        return
-    if processes == 0:
+    elif processes == 0:
         for line in trn:
             x = _trn_line_to_transcript((line, warn))
             if x is not None:

--- a/pydrobert/torch/data.py
+++ b/pydrobert/torch/data.py
@@ -577,7 +577,7 @@ def _trn_line_to_transcript(x):
     return utt_id, transcript
 
 
-def read_trn_iter(trn, warn=True, processes=0, chunksize=1000):
+def read_trn_iter(trn, warn=True, processes=0, chunk_size=1000):
     '''Read a NIST sclite transcript file, yielding individual transcripts
 
     Identical to :func:`read_trn_iter`, but yields individual transcript
@@ -598,7 +598,7 @@ def read_trn_iter(trn, warn=True, processes=0, chunksize=1000):
             with torch.multiprocessing.Pool(processes) as pool:
                 transcripts = pool.imap(
                     _trn_line_to_transcript, ((line, warn) for line in trn),
-                    chunksize)
+                    chunk_size)
                 for x in transcripts:
                     yield x
                 pool.close()
@@ -608,7 +608,7 @@ def read_trn_iter(trn, warn=True, processes=0, chunksize=1000):
             try:
                 transcripts = pool.imap(
                     _trn_line_to_transcript, ((line, warn) for line in trn),
-                    chunksize)
+                    chunk_size)
                 for x in transcripts:
                     yield x
                 pool.close()
@@ -617,7 +617,7 @@ def read_trn_iter(trn, warn=True, processes=0, chunksize=1000):
                 pool.terminate()
 
 
-def read_trn(trn, warn=True, processes=0, chunksize=1000):
+def read_trn(trn, warn=True, processes=0, chunk_size=1000):
     '''Read a NIST sclite transcript file into a list of transcripts
 
     `sclite <http://www1.icsi.berkeley.edu/Speech/docs/sctk-1.2/sclite.htm>`__
@@ -645,7 +645,7 @@ def read_trn(trn, warn=True, processes=0, chunksize=1000):
         The number of processes used to parse the lines of the trn file. If
         ``0``, will be performed on the main thread. Otherwise, the file will
         be read on the main thread and parsed using `processes` many processes
-    chunksize : int, optional
+    chunk_size : int, optional
         The number of lines to be processed by a worker process at a time.
         Applicable when ``processes > 0``
 
@@ -674,7 +674,7 @@ def read_trn(trn, warn=True, processes=0, chunksize=1000):
 
 
 def write_trn(transcripts, trn):
-    '''From a list of transcripts, write to a NIST "trn" file
+    '''From an iterable of transcripts, write to a NIST "trn" file
 
     This is largely the inverse operation of :func:`read_trn`. In general,
     elements of a transcript (`transcripts` contains pairs of ``utt_id,
@@ -685,7 +685,7 @@ def write_trn(transcripts, trn):
 
     Parameters
     ----------
-    transcripts : sequence
+    transcripts : iterable
     trn : file or str
     '''
     if isinstance(trn, basestring):

--- a/pydrobert/torch/data.py
+++ b/pydrobert/torch/data.py
@@ -1288,6 +1288,11 @@ class DataSetParams(param.Parameterized):
 
 class SpectDataParams(param.Parameterized):
     '''Parameters for spectral data'''
+    sos = param.Integer(
+        None, doc='A special symbol used to indicate the start of a sequence '
+        'in reference and hypothesis transcriptions. If set, `sos` will be '
+        'prepended to every reference transcription on read'
+    )
     eos = param.Integer(
         None, doc='A special symbol used to indicate the end of a sequence in '
         'reference and hypothesis transcriptions. If set, `eos` will be '
@@ -1517,6 +1522,7 @@ class SpectTrainingDataLoader(torch.utils.data.DataLoader):
             file_prefix=file_prefix, file_suffix=file_suffix,
             warn_on_missing=warn_on_missing,
             subset_ids=set(params.subset_ids) if params.subset_ids else None,
+            sos=self.data_params.sos,
             eos=self.data_params.eos,
             feat_subdir=feat_subdir, ali_subdir=ali_subdir,
             ref_subdir=ref_subdir,
@@ -1703,6 +1709,7 @@ class SpectEvaluationDataLoader(torch.utils.data.DataLoader):
             file_prefix=file_prefix, file_suffix=file_suffix,
             warn_on_missing=warn_on_missing,
             subset_ids=set(params.subset_ids) if params.subset_ids else None,
+            sos=self.data_params.sos,
             eos=self.data_params.eos,
             feat_subdir=feat_subdir, ali_subdir=ali_subdir,
             ref_subdir=ref_subdir,

--- a/pydrobert/torch/data.py
+++ b/pydrobert/torch/data.py
@@ -633,9 +633,17 @@ def read_trn(trn, warn=True, processes=0):
             if x is not None:
                 transcripts.append(x)
     else:
+        try:
         with torch.multiprocessing.Pool(processes) as pool:
             transcripts = pool.map(
                 _trn_line_to_transcript, ((line, warn) for line in trn))
+        except AttributeError:  # py2.7
+            pool = torch.multiprocessing.Pool(processes)
+            try:
+                transcripts = pool.map(
+                    _trn_line_to_transcript, ((line, warn) for line in trn))
+            finally:
+                pool.close()
     return transcripts
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ def populate_torch_dir():
             dr, num_utts, min_width=1, max_width=10, num_filts=5,
             max_class=10,
             include_ali=True, include_ref=True, file_prefix='',
-            file_suffix='.pt', seed=1):
+            file_suffix='.pt', seed=1, include_frame_shift=True):
         torch.manual_seed(seed)
         feat_dir = os.path.join(dr, 'feat')
         ali_dir = os.path.join(dr, 'ali')
@@ -76,15 +76,17 @@ def populate_torch_dir():
                 ref_size = torch.randint(1, feat_size + 1, (1,)).long().item()
                 max_ref_length = torch.randint(1, feat_size + 1, (1,)).long()
                 max_ref_length = max_ref_length.item()
-                ref_starts = torch.randint(
-                    feat_size - max_ref_length + 1, (ref_size,)).long()
-                ref_lengths = torch.randint(
-                    1, max_ref_length + 1, (ref_size,)).long()
-                ref = torch.stack([
-                    torch.randint(100, (ref_size,)).long(),
-                    ref_starts,
-                    ref_starts + ref_lengths,
-                ], dim=-1)
+                ref = torch.randint(100, (ref_size,)).long()
+                if include_frame_shift:
+                    ref_starts = torch.randint(
+                        feat_size - max_ref_length + 1, (ref_size,)).long()
+                    ref_lengths = torch.randint(
+                        1, max_ref_length + 1, (ref_size,)).long()
+                    ref = torch.stack([
+                        ref,
+                        ref_starts,
+                        ref_starts + ref_lengths,
+                    ], dim=-1)
                 torch.save(ref, os.path.join(
                     ref_dir, file_prefix + utt_id + file_suffix))
                 ref_sizes.append(ref_size)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,8 @@ def populate_torch_dir():
             dr, num_utts, min_width=1, max_width=10, num_filts=5,
             max_class=10,
             include_ali=True, include_ref=True, file_prefix='',
-            file_suffix='.pt', seed=1, include_frame_shift=True):
+            file_suffix='.pt', seed=1, include_frame_shift=True,
+            feat_dtype=torch.float):
         torch.manual_seed(seed)
         feat_dir = os.path.join(dr, 'feat')
         ali_dir = os.path.join(dr, 'ali')
@@ -61,7 +62,8 @@ def populate_torch_dir():
             utt_id = utt_id_fmt_str.format(utt_idx)
             feat_size = torch.randint(min_width, max_width + 1, (1,)).long()
             feat_size = feat_size.item()
-            feat = torch.rand(feat_size, num_filts)
+            feat = (torch.rand(feat_size, num_filts) * 1000).to(
+                dtype=feat_dtype)
             torch.save(feat, os.path.join(
                 feat_dir, file_prefix + utt_id + file_suffix))
             feats.append(feat)

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -126,7 +126,8 @@ A a (utt5)
 
 @pytest.mark.cpu
 @pytest.mark.parametrize('tokens', ['token2id', 'id2token'])
-def test_torch_token_data_dir_to_trn(temp_dir, tokens):
+@pytest.mark.parametrize('include_frame_shift', [True, False])
+def test_torch_token_data_dir_to_trn(temp_dir, tokens, include_frame_shift):
     torch.manual_seed(1000)
     num_utts = 100
     max_tokens = 10
@@ -143,7 +144,10 @@ def test_torch_token_data_dir_to_trn(temp_dir, tokens):
         utt_id = utt_fmt.format(utt_idx)
         num_tokens = torch.randint(max_tokens + 1, (1,)).long().item()
         ids = torch.randint(26, (num_tokens,)).long()
-        tok = torch.stack([ids] + ([torch.full_like(ids, -1)] * 2), -1)
+        if include_frame_shift:
+            tok = torch.stack([ids] + ([torch.full_like(ids, -1)] * 2), -1)
+        else:
+            tok = ids
         torch.save(tok, os.path.join(ref_dir, utt_id + '.pt'))
         transcript = ' '.join([chr(x + ord('a')) for x in ids.tolist()])
         transcript += ' ({})'.format(utt_id)

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -96,7 +96,8 @@ A a (utt5)
         assert not command_line.trn_to_torch_token_data_dir(
             [
                 trn_path, tokens_path, ref_dir,
-                '--alt-handler=first', '--unk-symbol=c'] +
+                '--alt-handler=first', '--unk-symbol=c',
+                '--chunk-size=1'] +
             (['--swap'] if tokens == 'id2token' else [])
         )
     act_utt1 = torch.load(os.path.join(ref_dir, 'utt1.pt'))

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -78,7 +78,8 @@ def _write_token2id(path, swap, collapse_vowels=False):
 
 @pytest.mark.cpu
 @pytest.mark.parametrize('tokens', ['token2id', 'id2token'])
-def test_trn_to_torch_token_data_dir(temp_dir, tokens):
+@pytest.mark.parametrize('skip_frame_times', [True, False])
+def test_trn_to_torch_token_data_dir(temp_dir, tokens, skip_frame_times):
     trn_path = os.path.join(temp_dir, 'ref.trn')
     tokens_path = os.path.join(temp_dir, 'token2id')
     ref_dir = os.path.join(temp_dir, 'ref')
@@ -98,21 +99,29 @@ A a (utt5)
                 trn_path, tokens_path, ref_dir,
                 '--alt-handler=first', '--unk-symbol=c',
                 '--chunk-size=1'] +
-            (['--swap'] if tokens == 'id2token' else [])
+            (['--swap'] if tokens == 'id2token' else []) +
+            (['--skip-frame-times'] if skip_frame_times else [])
         )
+    exp_utt1 = torch.tensor([0, 1, 1, 2])
+    exp_utt3 = torch.tensor([3, 4, 6])
+    exp_utt4 = torch.tensor([7])
+    exp_utt5 = torch.tensor([2, 0])
+    if not skip_frame_times:
+        neg1_tensor = torch.tensor([[-1, -1]] * 10)
+        exp_utt1 = torch.cat([exp_utt1.unsqueeze(-1), neg1_tensor[:4]], -1)
+        exp_utt3 = torch.cat([exp_utt3.unsqueeze(-1), neg1_tensor[:3]], -1)
+        exp_utt4 = torch.cat([exp_utt4.unsqueeze(-1), neg1_tensor[:1]], -1)
+        exp_utt5 = torch.cat([exp_utt5.unsqueeze(-1), neg1_tensor[:2]], -1)
     act_utt1 = torch.load(os.path.join(ref_dir, 'utt1.pt'))
-    assert torch.all(act_utt1 == torch.tensor([
-        [0, -1, -1], [1, -1, -1], [1, -1, -1], [2, -1, -1]]))
+    assert torch.all(act_utt1 == exp_utt1)
     act_utt2 = torch.load(os.path.join(ref_dir, 'utt2.pt'))
     assert not act_utt2.numel()
     act_utt3 = torch.load(os.path.join(ref_dir, 'utt3.pt'))
-    assert torch.all(act_utt3 == torch.tensor([
-        [3, -1, -1], [4, -1, -1], [6, -1, -1]]))
+    assert torch.all(act_utt3 == exp_utt3)
     act_utt4 = torch.load(os.path.join(ref_dir, 'utt4.pt'))
-    assert torch.all(act_utt4 == torch.tensor([[7, -1, -1]]))
+    assert torch.all(act_utt4 == exp_utt4)
     act_utt5 = torch.load(os.path.join(ref_dir, 'utt5.pt'))
-    assert torch.all(act_utt5 == torch.tensor([
-        [2, -1, -1], [0, -1, -1]]))
+    assert torch.all(act_utt5 == exp_utt5)
 
 
 @pytest.mark.cpu

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -366,26 +366,27 @@ last A 0.0 10.0111 hullo
 
 
 @pytest.mark.cpu
-@pytest.mark.parametrize('transcript,token2id,unk,exp', [
-    ([], None, None, torch.LongTensor(0, 3)),
+@pytest.mark.parametrize('transcript,token2id,unk,skip_frame_times,exp', [
+    ([], None, None, False, torch.LongTensor(0, 3)),
     (
         [1, 2, 3, 4],
-        None, None,
-        torch.LongTensor([[1, -1, -1], [2, -1, -1], [3, -1, -1], [4, -1, -1]]),
+        None, None, True,
+        torch.LongTensor([1, 2, 3, 4]),
     ),
     (
         [1, ('a', 4, 10), 'a', 3],
-        {'a': 2}, None,
+        {'a': 2}, None, False,
         torch.LongTensor([[1, -1, -1], [2, 4, 10], [2, -1, -1], [3, -1, -1]]),
     ),
     (
         ['foo', 1, 'bar'],
-        {'foo': 0, 'baz': 3}, 'baz',
+        {'foo': 0, 'baz': 3}, 'baz', False,
         torch.LongTensor([[0, -1, -1], [3, -1, -1], [3, -1, -1]]),
     ),
 ])
-def test_transcript_to_token(transcript, token2id, unk, exp):
-    act = data.transcript_to_token(transcript, token2id, unk=unk)
+def test_transcript_to_token(transcript, token2id, unk, skip_frame_times, exp):
+    act = data.transcript_to_token(
+        transcript, token2id, unk=unk, skip_frame_times=skip_frame_times)
     assert torch.all(exp == act)
     transcript = ['foo'] + transcript
     with pytest.raises(Exception):
@@ -404,7 +405,8 @@ def test_transcript_to_token(transcript, token2id, unk, exp):
         torch.LongTensor([[1, 3, 4], [3, 4, 5], [2, -1, -1]]),
         {1: 'a', 2: 'b'},
         [('a', 3, 4), (3, 4, 5), 'b'],
-    )
+    ),
+    (torch.tensor(range(10)), None, list(range(10))),
 ])
 def test_token_to_transcript(tok, id2token, exp):
     act = data.token_to_transcript(tok, id2token)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -235,7 +235,7 @@ here is a simple example (a)
 nothing should go wrong (b)
 ''')
     trn.seek(0)
-    act = data.read_trn(trn, processes=processes)
+    act = data.read_trn(trn, processes=processes, chunk_size=1)
     assert act == [
         ('a', ['here', 'is', 'a', 'simple', 'example']),
         ('b', ['nothing', 'should', 'go', 'wrong']),

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -227,14 +227,15 @@ def test_spect_data_set_validity(temp_dir, eos):
 
 
 @pytest.mark.cpu
-def test_read_trn():
+@pytest.mark.parametrize('processes', [0, 2])
+def test_read_trn(processes):
     trn = StringIO()
     trn.write('''\
 here is a simple example (a)
 nothing should go wrong (b)
 ''')
     trn.seek(0)
-    act = data.read_trn(trn)
+    act = data.read_trn(trn, processes=processes)
     assert act == [
         ('a', ['here', 'is', 'a', 'simple', 'example']),
         ('b', ['nothing', 'should', 'go', 'wrong']),
@@ -247,7 +248,7 @@ here is an { example /with} some alternates (a)
 a11 (d)
 ''')
     trn.seek(0)
-    act = data.read_trn(trn, warn=False)
+    act = data.read_trn(trn, warn=False, processes=processes)
     assert act == [
         ('a', [
             'here', 'is', 'an',


### PR DESCRIPTION
In preparation for handling the Gigaword Summarization task in pytorch-database-prep, the following updates have been made to some command line and data processing routines. **Some of these can break prior functionality.**

- NIST transcription file reading now uses multiprocessing.
- An iterable version of `read_trn` has also been provided so that transcriptions need not all be in memory.
- `trn-to-torch-token-data-dir` now relies on `read_trn_iter`, making it less memory intensive. It also uses multiprocessing to run faster.
- Data in the ``ref/`` folder can now be of shape ``(R,)`` instead of ``(R, 3)`` if there is no alignment information, reducing the size of the folder by two thirds in this case. Classes, functions, and command-line hooks dealing with "token directories" have been updated to handle this. **SpectDataSet will be considered valid with either dimension**, as long as the choice is consistent within `ref/`.
- `torch-token-data-dir-to-trn` likewise has been updated with multiprocessing.
- A start-of-sequence token is now an optional argument for `SpectDataSet` and `SpectDataSetParams`. If set, the token will be prepended to reference transcriptions and deleted from hypothesis transcriptions, similar to the end-of-sequence token. The sos token keyword argument occurs before the eos token keyword argument, meaning **code that passes keyword arguments as positional arguments will treat eos as sos**. 
- **Data in the `feat/` directory can now be any tensor type**, as long as that type is consistent within the directory. Feature data are still right-padded with zeros in batches, regardless of the type.
- Flags have been added to `trn-to-torch-token-data-dir` to suppress the frame alignment info (generating tensors of shape ``(R,)``) or suppress the frame alignment info *and* unsqueeze the transcription to size ``(R, 1)``. This allows one to treat a source sentence as "features" for a `SpectDataSet`.