### PR TITLE
Handle raw features in ctm<->ref with floating point frame shift

### DIFF
--- a/pydrobert/torch/command_line.py
+++ b/pydrobert/torch/command_line.py
@@ -34,55 +34,56 @@ __email__ = "sdrobert@cs.toronto.edu"
 __license__ = "Apache 2.0"
 __copyright__ = "Copyright 2019 Sean Robertson"
 __all__ = [
-    'compute_torch_token_data_dir_error_rates',
-    'ctm_to_torch_token_data_dir',
-    'get_torch_spect_data_dir_info',
-    'torch_token_data_dir_to_ctm',
-    'torch_token_data_dir_to_trn',
-    'trn_to_torch_token_data_dir',
+    "compute_torch_token_data_dir_error_rates",
+    "ctm_to_torch_token_data_dir",
+    "get_torch_spect_data_dir_info",
+    "torch_token_data_dir_to_ctm",
+    "torch_token_data_dir_to_trn",
+    "trn_to_torch_token_data_dir",
 ]
 
 
 def _get_torch_spect_data_dir_info_parse_args(args):
-    parser = argparse.ArgumentParser(
-        description=get_torch_spect_data_dir_info.__doc__,
-    )
-    parser.add_argument('dir', type=str, help='The torch data directory')
+    parser = argparse.ArgumentParser(description=get_torch_spect_data_dir_info.__doc__,)
+    parser.add_argument("dir", type=str, help="The torch data directory")
     parser.add_argument(
-        'out_file', nargs='?', type=argparse.FileType('w'),
+        "out_file",
+        nargs="?",
+        type=argparse.FileType("w"),
         default=sys.stdout,
-        help='The file to write to. If unspecified, stdout',
+        help="The file to write to. If unspecified, stdout",
     )
     parser.add_argument(
-        '--strict', action='store_true', default=False,
-        help='If set, validate the data directory before collecting info. The '
-        'process is described in pydrobert.torch.data.validate_spect_data_set'
+        "--strict",
+        action="store_true",
+        default=False,
+        help="If set, validate the data directory before collecting info. The "
+        "process is described in pydrobert.torch.data.validate_spect_data_set",
     )
     parser.add_argument(
-        '--file-prefix', default='',
-        help='The file prefix indicating a torch data file'
+        "--file-prefix", default="", help="The file prefix indicating a torch data file"
     )
     parser.add_argument(
-        '--file-suffix', default='.pt',
-        help='The file suffix indicating a torch data file'
+        "--file-suffix",
+        default=".pt",
+        help="The file suffix indicating a torch data file",
     )
     parser.add_argument(
-        '--feat-subdir', default='feat',
-        help='Subdirectory where features are stored'
+        "--feat-subdir", default="feat", help="Subdirectory where features are stored"
     )
     parser.add_argument(
-        '--ali-subdir', default='ali',
-        help='Subdirectory where alignments are stored'
+        "--ali-subdir", default="ali", help="Subdirectory where alignments are stored"
     )
     parser.add_argument(
-        '--ref-subdir', default='ref',
-        help='Subdirectory where reference token sequences are stored'
+        "--ref-subdir",
+        default="ref",
+        help="Subdirectory where reference token sequences are stored",
     )
     return parser.parse_args(args)
 
 
 def get_torch_spect_data_dir_info(args=None):
-    '''Write info about the specified SpectDataSet data dir
+    """Write info about the specified SpectDataSet data dir
 
     A torch :class:`pydrobert.torch.data.SpectDataSet` data dir is of the
     form::
@@ -131,7 +132,7 @@ def get_torch_spect_data_dir_info(args=None):
 
     Note that the output can be parsed as a `Kaldi <http://kaldi-asr.org/>`__
     text table of integers.
-    '''
+    """
     try:
         options = _get_torch_spect_data_dir_info_parse_args(args)
     except SystemExit as ex:
@@ -150,37 +151,37 @@ def get_torch_spect_data_dir_info(args=None):
     if options.strict:
         data.validate_spect_data_set(data_set)
     info_dict = {
-        'num_utterances': len(data_set),
-        'total_frames': 0,
-        'max_ali_class': -1,
-        'max_ref_class': -1,
+        "num_utterances": len(data_set),
+        "total_frames": 0,
+        "max_ali_class": -1,
+        "max_ref_class": -1,
     }
     counts = dict()
     for feat, ali, ref in data_set:
-        info_dict['num_filts'] = feat.size()[1]
-        info_dict['total_frames'] += feat.size()[0]
+        info_dict["num_filts"] = feat.size()[1]
+        info_dict["total_frames"] += feat.size()[0]
         if ali is not None:
             for class_idx in ali:
                 class_idx = class_idx.item()
                 if class_idx < 0:
-                    raise ValueError('Got a negative ali class idx')
-                info_dict['max_ali_class'] = max(
-                    class_idx, info_dict['max_ali_class'])
+                    raise ValueError("Got a negative ali class idx")
+                info_dict["max_ali_class"] = max(class_idx, info_dict["max_ali_class"])
                 counts[class_idx] = counts.get(class_idx, 0) + 1
         if ref is not None:
             ref = ref[..., 0]
             if ref.min().item() < 0:
-                raise ValueError('Got a negative ref class idx')
-            info_dict['max_ref_class'] = max(
-                info_dict['max_ref_class'], ref.max().item())
-    if info_dict['max_ali_class'] == 0:
-        info_dict['count_0'] = counts[0]
-    elif info_dict['max_ali_class'] > 0:
-        count_fmt_str = 'count_{{:0{}d}}'.format(
-            int(math.log10(info_dict['max_ali_class'])) + 1)
-        for class_idx in range(info_dict['max_ali_class'] + 1):
-            info_dict[count_fmt_str.format(class_idx)] = counts.get(
-                class_idx, 0)
+                raise ValueError("Got a negative ref class idx")
+            info_dict["max_ref_class"] = max(
+                info_dict["max_ref_class"], ref.max().item()
+            )
+    if info_dict["max_ali_class"] == 0:
+        info_dict["count_0"] = counts[0]
+    elif info_dict["max_ali_class"] > 0:
+        count_fmt_str = "count_{{:0{}d}}".format(
+            int(math.log10(info_dict["max_ali_class"])) + 1
+        )
+        for class_idx in range(info_dict["max_ali_class"] + 1):
+            info_dict[count_fmt_str.format(class_idx)] = counts.get(class_idx, 0)
     info_list = sorted(info_dict.items())
     for key, value in info_list:
         options.out_file.write("{} {}\n".format(key, value))
@@ -190,70 +191,79 @@ def get_torch_spect_data_dir_info(args=None):
 
 
 def _trn_to_torch_token_data_dir_parse_args(args):
-    parser = argparse.ArgumentParser(
-        description=trn_to_torch_token_data_dir.__doc__,
+    parser = argparse.ArgumentParser(description=trn_to_torch_token_data_dir.__doc__,)
+    parser.add_argument("trn", type=argparse.FileType("r"), help="The input trn file")
+    parser.add_argument(
+        "token2id",
+        type=argparse.FileType("r"),
+        help="A file containing mappings from tokens (e.g. words or phones) "
+        "to unique IDs. Each line has the format ``<token> <id>``. The flag "
+        "``--swap`` can be used to swap the expected ordering (i.e. "
+        "``<id> <token>``)",
     )
     parser.add_argument(
-        'trn', type=argparse.FileType('r'),
-        help='The input trn file'
+        "dir",
+        help="The directory to store token sequences to. If the directory "
+        "does not exist, it will be created",
     )
     parser.add_argument(
-        'token2id', type=argparse.FileType('r'),
-        help='A file containing mappings from tokens (e.g. words or phones) '
-        'to unique IDs. Each line has the format ``<token> <id>``. The flag '
-        '``--swap`` can be used to swap the expected ordering (i.e. '
-        '``<id> <token>``)'
-    )
-    parser.add_argument(
-        'dir',
-        help='The directory to store token sequences to. If the directory '
-        'does not exist, it will be created'
-    )
-    parser.add_argument(
-        '--alt-handler', default='error', choices=('error', 'first'),
+        "--alt-handler",
+        default="error",
+        choices=("error", "first"),
         help='How to handle transcription alternates. If "error", error if '
         'the "trn" file contains alternates. If "first", always treat the '
-        'alternate as canon'
+        "alternate as canon",
     )
     parser.add_argument(
-        '--file-prefix', default='',
-        help='The file prefix indicating a torch data file'
+        "--file-prefix", default="", help="The file prefix indicating a torch data file"
     )
     parser.add_argument(
-        '--file-suffix', default='.pt',
-        help='The file suffix indicating a torch data file'
+        "--file-suffix",
+        default=".pt",
+        help="The file suffix indicating a torch data file",
     )
     parser.add_argument(
-        '--swap', action='store_true', default=False,
-        help='If set, swaps the order of key and value in `token2id`'
+        "--swap",
+        action="store_true",
+        default=False,
+        help="If set, swaps the order of key and value in `token2id`",
     )
     parser.add_argument(
-        '--unk-symbol', default=None,
-        help='If set, will map out-of-vocabulary tokens to this symbol'
+        "--unk-symbol",
+        default=None,
+        help="If set, will map out-of-vocabulary tokens to this symbol",
     )
     parser.add_argument(
-        '--num-workers', type=int, default=torch.multiprocessing.cpu_count(),
-        help='The number of workers to spawn to process the data. 0 is serial.'
-        ' Defaults to the cpu count'
+        "--num-workers",
+        type=int,
+        default=torch.multiprocessing.cpu_count(),
+        help="The number of workers to spawn to process the data. 0 is serial."
+        " Defaults to the cpu count",
     )
     parser.add_argument(
-        '--chunk-size', type=int, default=1000,
-        help='The number of lines that a worker will process at once. Impacts '
-        'speed and memory consumption.'
+        "--chunk-size",
+        type=int,
+        default=1000,
+        help="The number of lines that a worker will process at once. Impacts "
+        "speed and memory consumption.",
     )
     size_group = parser.add_mutually_exclusive_group()
     size_group.add_argument(
-        '--skip-frame-times', action='store_true', default=False,
-        help='If true, will store token tensors of shape (R,) instead of '
-        '(R, 3), foregoing segment start and end times (which trn does not '
-        'have).'
+        "--skip-frame-times",
+        action="store_true",
+        default=False,
+        help="If true, will store token tensors of shape (R,) instead of "
+        "(R, 3), foregoing segment start and end times (which trn does not "
+        "have).",
     )
     size_group.add_argument(
-        '--feat-sizing', action='store_true', default=False,
-        help='If true, will store token tensors of shape (R, 1) instead of '
-        '(R, 3), foregoing segment start and end times (which trn does not '
-        'have). The extra dimension will allow data in this directory to be '
-        'loaded as features in a SpectDataSet.'
+        "--feat-sizing",
+        action="store_true",
+        default=False,
+        help="If true, will store token tensors of shape (R, 1) instead of "
+        "(R, 3), foregoing segment start and end times (which trn does not "
+        "have). The extra dimension will allow data in this directory to be "
+        "loaded as features in a SpectDataSet.",
     )
     return parser.parse_args(args)
 
@@ -266,34 +276,50 @@ def _parse_token2id(file, swap, return_swap):
         if not line:
             continue
         ls = line.split()
-        if len(ls) != 2 or not ls[1 - int(swap)].lstrip('-').isdigit():
+        if len(ls) != 2 or not ls[1 - int(swap)].lstrip("-").isdigit():
             raise ValueError(
-                'Cannot parse line {} of {}'.format(line_no + 1, file.name))
+                "Cannot parse line {} of {}".format(line_no + 1, file.name)
+            )
         key, value = ls
         key, value = (int(key), value) if swap else (key, int(value))
         if key in ret:
             warnings.warn(
                 '{} line {}: "{}" already exists. Mapping will be ambiguous'
-                ''.format(file.name, line_no + 1, key))
+                "".format(file.name, line_no + 1, key)
+            )
         if value in ret_swapped:
             warnings.warn(
                 '{} line {}: "{}" already exists. Mapping will be ambiguous'
-                ''.format(file.name, line_no + 1, value))
+                "".format(file.name, line_no + 1, value)
+            )
         ret[key] = value
         ret_swapped[value] = key
     return ret_swapped if return_swap else ret
 
 
 def _save_transcripts_to_dir_worker(
-        token2id, file_prefix, file_suffix, dir_, frame_shift_ms, unk,
-        skip_frame_times, feat_sizing, queue, first_timeout=30,
-        rest_timeout=10):
+    token2id,
+    file_prefix,
+    file_suffix,
+    dir_,
+    frame_shift_ms,
+    unk,
+    skip_frame_times,
+    feat_sizing,
+    queue,
+    first_timeout=30,
+    rest_timeout=10,
+):
     transcripts = queue.get(True, first_timeout)
     while transcripts is not None:
         for utt_id, transcript in transcripts:
             tok = data.transcript_to_token(
-                transcript, token2id, frame_shift_ms, unk,
-                skip_frame_times or feat_sizing)
+                transcript,
+                token2id,
+                frame_shift_ms,
+                unk,
+                skip_frame_times or feat_sizing,
+            )
             if feat_sizing:
                 tok = tok.unsqueeze(-1)
             path = os.path.join(dir_, file_prefix + utt_id + file_suffix)
@@ -302,21 +328,38 @@ def _save_transcripts_to_dir_worker(
 
 
 def _save_transcripts_to_dir(
-        transcripts, token2id, file_prefix, file_suffix, dir_,
-        frame_shift_ms=None, unk=None, skip_frame_times=False,
-        feat_sizing=False, num_workers=0, chunk_size=1000):
+    transcripts,
+    token2id,
+    file_prefix,
+    file_suffix,
+    dir_,
+    frame_shift_ms=None,
+    unk=None,
+    skip_frame_times=False,
+    feat_sizing=False,
+    num_workers=0,
+    chunk_size=1000,
+):
     if not os.path.isdir(dir_):
         os.makedirs(dir_)
     if num_workers:
         queue = torch.multiprocessing.Queue(num_workers)
         try:
             with torch.multiprocessing.Pool(
-                    num_workers, _save_transcripts_to_dir_worker,
-                    (
-                        token2id, file_prefix, file_suffix, dir_,
-                        frame_shift_ms, unk, skip_frame_times, feat_sizing,
-                        queue
-                    )) as pool:
+                num_workers,
+                _save_transcripts_to_dir_worker,
+                (
+                    token2id,
+                    file_prefix,
+                    file_suffix,
+                    dir_,
+                    frame_shift_ms,
+                    unk,
+                    skip_frame_times,
+                    feat_sizing,
+                    queue,
+                ),
+            ) as pool:
                 chunk = tuple(itertools.islice(transcripts, chunk_size))
                 while len(chunk):
                     queue.put(chunk)
@@ -327,11 +370,19 @@ def _save_transcripts_to_dir(
                 pool.join()
         except AttributeError:  # 2.7
             pool = torch.multiprocessing.Pool(
-                num_workers, _save_transcripts_to_dir_worker,
+                num_workers,
+                _save_transcripts_to_dir_worker,
                 (
-                    token2id, file_prefix, file_suffix, dir_,
-                    frame_shift_ms, unk, skip_frame_times, queue
-                ))
+                    token2id,
+                    file_prefix,
+                    file_suffix,
+                    dir_,
+                    frame_shift_ms,
+                    unk,
+                    skip_frame_times,
+                    queue,
+                ),
+            )
             try:
                 chunk = tuple(itertools.islice(transcripts, chunk_size))
                 while len(chunk):
@@ -346,8 +397,12 @@ def _save_transcripts_to_dir(
     else:
         for utt_id, transcript in transcripts:
             tok = data.transcript_to_token(
-                transcript, token2id, frame_shift_ms, unk,
-                skip_frame_times or feat_sizing)
+                transcript,
+                token2id,
+                frame_shift_ms,
+                unk,
+                skip_frame_times or feat_sizing,
+            )
             if feat_sizing:
                 tok = tok.unsqueeze(-1)
             path = os.path.join(dir_, file_prefix + utt_id + file_suffix)
@@ -355,7 +410,7 @@ def _save_transcripts_to_dir(
 
 
 def trn_to_torch_token_data_dir(args=None):
-    '''Convert a NIST "trn" file to the specified SpectDataSet data dir
+    """Convert a NIST "trn" file to the specified SpectDataSet data dir
 
     A "trn" file is the standard transcription file without alignment
     information used in the `sclite
@@ -371,17 +426,17 @@ def trn_to_torch_token_data_dir(args=None):
     :func:`get_torch_spect_data_dir_info` (command line
     "get-torch-spect-data-dir-info") for more information on a
     :class:`pydrobert.torch.data.SpectDataSet`
-    '''
+    """
     try:
         options = _trn_to_torch_token_data_dir_parse_args(args)
     except SystemExit as ex:
         return ex.code
-    token2id = _parse_token2id(
-        options.token2id, options.swap, options.swap)
+    token2id = _parse_token2id(options.token2id, options.swap, options.swap)
     if options.unk_symbol is not None and options.unk_symbol not in token2id:
         print(
             'Unk symbol "{}" is not in token2id'.format(options.unk_symbol),
-            file=sys.stderr)
+            file=sys.stderr,
+        )
         return 1
     # we're going to do all the threading on the tensor creation part of
     # things
@@ -397,71 +452,79 @@ def trn_to_torch_token_data_dir(args=None):
                     x = x[0]
                 if isinstance(x, str):
                     transcript.append(x)
-                elif options.alt_handler == 'error':
-                    raise ValueError(
-                        'Cannot handle alternate in "{}"'.format(utt_id))
+                elif options.alt_handler == "error":
+                    raise ValueError('Cannot handle alternate in "{}"'.format(utt_id))
                 else:  # first
                     x[0].extend(old_transcript)
                     old_transcript = x[0]
             yield utt_id, transcript
+
     _save_transcripts_to_dir(
-        error_handling_iter(), token2id, options.file_prefix,
-        options.file_suffix, options.dir, unk=options.unk_symbol,
+        error_handling_iter(),
+        token2id,
+        options.file_prefix,
+        options.file_suffix,
+        options.dir,
+        unk=options.unk_symbol,
         skip_frame_times=options.skip_frame_times,
         feat_sizing=options.feat_sizing,
-        num_workers=options.num_workers, chunk_size=options.chunk_size)
+        num_workers=options.num_workers,
+        chunk_size=options.chunk_size,
+    )
     return 0
 
 
 def _torch_token_data_dir_to_trn_parse_args(args=None):
-    parser = argparse.ArgumentParser(
-        description=torch_token_data_dir_to_trn.__doc__)
+    parser = argparse.ArgumentParser(description=torch_token_data_dir_to_trn.__doc__)
+    parser.add_argument("dir", help="The directory to read token sequences from")
     parser.add_argument(
-        'dir', help='The directory to read token sequences from')
-    parser.add_argument(
-        'id2token', type=argparse.FileType('r'),
-        help='A file containing the mappings from unique IDs to tokens (e.g. '
-        'words or phones). Each line has the format ``<id> <token>``. The '
-        'flag ``--swap`` can be used to swap the expected ordering (i.e. '
-        '``<token> <id>``)'
+        "id2token",
+        type=argparse.FileType("r"),
+        help="A file containing the mappings from unique IDs to tokens (e.g. "
+        "words or phones). Each line has the format ``<id> <token>``. The "
+        "flag ``--swap`` can be used to swap the expected ordering (i.e. "
+        "``<token> <id>``)",
     )
     parser.add_argument(
-        "trn", type=argparse.FileType('w'),
-        help='The "trn" file to write transcriptions to'
+        "trn",
+        type=argparse.FileType("w"),
+        help='The "trn" file to write transcriptions to',
     )
     parser.add_argument(
-        '--file-prefix', default='',
-        help='The file prefix indicating a torch data file'
+        "--file-prefix", default="", help="The file prefix indicating a torch data file"
     )
     parser.add_argument(
-        '--file-suffix', default='.pt',
-        help='The file suffix indicating a torch data file'
+        "--file-suffix",
+        default=".pt",
+        help="The file suffix indicating a torch data file",
     )
     parser.add_argument(
-        '--swap', action='store_true', default=False,
-        help='If set, swaps the order of key and value in `id2token`'
+        "--swap",
+        action="store_true",
+        default=False,
+        help="If set, swaps the order of key and value in `id2token`",
     )
     parser.add_argument(
-        '--num-workers', type=int, default=torch.multiprocessing.cpu_count(),
-        help='The number of workers to spawn to process the data. 0 is serial.'
-        ' Defaults to the cpu count'
+        "--num-workers",
+        type=int,
+        default=torch.multiprocessing.cpu_count(),
+        help="The number of workers to spawn to process the data. 0 is serial."
+        " Defaults to the cpu count",
     )
     return parser.parse_args(args)
 
 
 class _TranscriptDataSet(torch.utils.data.Dataset):
-
     def __init__(
-            self, dir_, id2token, file_prefix, file_suffix,
-            frame_shift_ms, strip_timing):
+        self, dir_, id2token, file_prefix, file_suffix, frame_shift_ms, strip_timing
+    ):
         super(_TranscriptDataSet, self).__init__()
         fpl = len(file_prefix)
         neg_fsl = -len(file_suffix)
         self.utt_ids = sorted(
             x[fpl:neg_fsl]
             for x in os.listdir(dir_)
-            if x.startswith(file_prefix) and
-            x.endswith(file_suffix)
+            if x.startswith(file_prefix) and x.endswith(file_suffix)
         )
         self.dir_ = dir_
         self.file_prefix = file_prefix
@@ -472,10 +535,10 @@ class _TranscriptDataSet(torch.utils.data.Dataset):
 
     def __getitem__(self, index):
         utt_id = self.utt_ids[index]
-        tok = torch.load(os.path.join(
-            self.dir_, self.file_prefix + utt_id + self.file_suffix))
-        transcript = data.token_to_transcript(
-            tok, self.id2token, self.frame_shift_ms)
+        tok = torch.load(
+            os.path.join(self.dir_, self.file_prefix + utt_id + self.file_suffix)
+        )
+        transcript = data.token_to_transcript(tok, self.id2token, self.frame_shift_ms)
         for idx in range(len(transcript)):
             token = transcript[idx]
             if isinstance(token, tuple):
@@ -486,7 +549,8 @@ class _TranscriptDataSet(torch.utils.data.Dataset):
                 assert token not in self.id2token
                 raise ValueError(
                     'Utterance "{}": ID "{}" could not be found in id2token'
-                    ''.format(utt_id, token))
+                    "".format(utt_id, token)
+                )
         return utt_id, transcript
 
     def __len__(self):
@@ -498,20 +562,27 @@ def _noop_collate(x):
 
 
 def _load_transcripts_from_data_dir(
-        dir_, id2token, file_prefix, file_suffix, frame_shift_ms=None,
-        strip_timing=False, num_workers=0):
+    dir_,
+    id2token,
+    file_prefix,
+    file_suffix,
+    frame_shift_ms=None,
+    strip_timing=False,
+    num_workers=0,
+):
     ds = _TranscriptDataSet(
-        dir_, id2token, file_prefix, file_suffix, frame_shift_ms,
-        strip_timing)
+        dir_, id2token, file_prefix, file_suffix, frame_shift_ms, strip_timing
+    )
     dl = torch.utils.data.DataLoader(
-        ds, batch_size=1, num_workers=num_workers, collate_fn=_noop_collate)
+        ds, batch_size=1, num_workers=num_workers, collate_fn=_noop_collate
+    )
     for utt_ids, transcripts in dl:
         yield utt_ids, transcripts
     del dl, ds
 
 
 def torch_token_data_dir_to_trn(args=None):
-    '''Convert a SpectDataSet token data dir to a NIST trn file
+    """Convert a SpectDataSet token data dir to a NIST trn file
 
     A "trn" file is the standard transcription file without alignment
     information used in the `sclite
@@ -527,7 +598,7 @@ def torch_token_data_dir_to_trn(args=None):
     file. See the command :func:`get_torch_spect_data_dir_info` (command line
     "get-torch-spect-data-dir-info") for more information on a
     :class:`pydrobert.torch.data.SpectDataSet`.
-    '''
+    """
     try:
         options = _torch_token_data_dir_to_trn_parse_args(args)
     except SystemExit as ex:
@@ -535,67 +606,86 @@ def torch_token_data_dir_to_trn(args=None):
     if not os.path.isdir(options.dir):
         print('"{}" is not a directory'.format(options.dir), file=sys.stderr)
         return 1
-    id2token = _parse_token2id(
-        options.id2token, not options.swap, options.swap)
+    id2token = _parse_token2id(options.id2token, not options.swap, options.swap)
     transcripts = _load_transcripts_from_data_dir(
-        options.dir, id2token, options.file_prefix, options.file_suffix,
-        strip_timing=True, num_workers=options.num_workers)
+        options.dir,
+        id2token,
+        options.file_prefix,
+        options.file_suffix,
+        strip_timing=True,
+        num_workers=options.num_workers,
+    )
     data.write_trn(transcripts, options.trn)
     return 0
 
 
 def _ctm_to_torch_token_data_dir_parse_args(args):
-    parser = argparse.ArgumentParser(
-        description=ctm_to_torch_token_data_dir.__doc__)
+    parser = argparse.ArgumentParser(description=ctm_to_torch_token_data_dir.__doc__)
     parser.add_argument(
-        'ctm', type=argparse.FileType('r'),
-        help='The "ctm" file to read token segments from')
-    parser.add_argument(
-        'token2id', type=argparse.FileType('r'),
-        help='A file containing mappings from tokens (e.g. words or phones) '
-        'to unique IDs. Each line has the format ``<token> <id>``. The flag '
-        '``--swap`` can be used to swap the expected ordering (i.e. '
-        '``<id> <token>``)'
+        "ctm",
+        type=argparse.FileType("r"),
+        help='The "ctm" file to read token segments from',
     )
     parser.add_argument(
-        'dir', help='The directory to store token sequences to. If the '
-        'directory does not exist, it will be created'
+        "token2id",
+        type=argparse.FileType("r"),
+        help="A file containing mappings from tokens (e.g. words or phones) "
+        "to unique IDs. Each line has the format ``<token> <id>``. The flag "
+        "``--swap`` can be used to swap the expected ordering (i.e. "
+        "``<id> <token>``)",
     )
     parser.add_argument(
-        '--file-prefix', default='',
-        help='The file prefix indicating a torch data file'
+        "dir",
+        help="The directory to store token sequences to. If the "
+        "directory does not exist, it will be created",
     )
     parser.add_argument(
-        '--file-suffix', default='.pt',
-        help='The file suffix indicating a torch data file'
+        "--file-prefix", default="", help="The file prefix indicating a torch data file"
     )
     parser.add_argument(
-        '--swap', action='store_true', default=False,
-        help='If set, swaps the order of key and value in `token2id`'
+        "--file-suffix",
+        default=".pt",
+        help="The file suffix indicating a torch data file",
     )
     parser.add_argument(
-        '--frame-shift-ms', type=int, default=10,
-        help='The number of milliseconds that have passed between consecutive '
-        'frames. Used to convert between time in seconds and frame index'
+        "--swap",
+        action="store_true",
+        default=False,
+        help="If set, swaps the order of key and value in `token2id`",
+    )
+    parser.add_argument(
+        "--frame-shift-ms",
+        type=float,
+        default=10.0,
+        help="The number of milliseconds that have passed between consecutive "
+        "frames. Used to convert between time in seconds and frame index. If your "
+        "features are the raw sample, set this to 1000 / sample_rate_hz",
     )
     utt_group = parser.add_mutually_exclusive_group()
     utt_group.add_argument(
-        '--wc2utt', type=argparse.FileType('r'), default=None,
-        help='A file mapping wavefile name and channel combinations (e.g. '
-        '``utt_1 A``) to utterance IDs. Each line of the file has the format '
+        "--wc2utt",
+        type=argparse.FileType("r"),
+        default=None,
+        help="A file mapping wavefile name and channel combinations (e.g. "
+        "``utt_1 A``) to utterance IDs. Each line of the file has the format "
         '``<wavefile_name> <channel> <utt_id>``. If neither "--wc2utt" nor '
         '"--utt2wc" has been specied, the wavefile name will be treated as '
-        'the utterance ID')
+        "the utterance ID",
+    )
     utt_group.add_argument(
-        '--utt2wc', type=argparse.FileType('r'), default=None,
-        help='A file mapping utterance IDs to wavefile name and channel '
-        'combinations (e.g. ``utt_1 A``). Each line of the file has the '
+        "--utt2wc",
+        type=argparse.FileType("r"),
+        default=None,
+        help="A file mapping utterance IDs to wavefile name and channel "
+        "combinations (e.g. ``utt_1 A``). Each line of the file has the "
         'format ``<utt_id> <wavefile_name> <channel>``. If neither "--wc2utt" '
         'nor "--utt2wc" has been specied, the wavefile name will be treated '
-        'as the utterance ID')
+        "as the utterance ID",
+    )
     parser.add_argument(
-        '--unk-symbol', default=None,
-        help='If set, will map out-of-vocabulary tokens to this symbol'
+        "--unk-symbol",
+        default=None,
+        help="If set, will map out-of-vocabulary tokens to this symbol",
     )
     return parser.parse_args(args)
 
@@ -610,19 +700,19 @@ def _parse_wc2utt(file, swap, return_swap):
         ls = line.split()
         if len(ls) != 3:
             raise ValueError(
-                'Cannot parse line {} of {}'.format(line_no + 1, file.name),
+                "Cannot parse line {} of {}".format(line_no + 1, file.name),
             )
         first, mid, last = ls
         key, value = ((mid, last), first) if swap else ((first, mid), last)
         if key in ret:
             warnings.warn(
                 '{} line {}: "{}" already exists. Mapping will be '
-                ''.format(file.name, line_no + 1, key)
+                "".format(file.name, line_no + 1, key)
             )
         if value in ret_swapped:
             warnings.warn(
                 '{} line {}: "{}" already exists. Mapping will be '
-                ''.format(file.name, line_no + 1, value)
+                "".format(file.name, line_no + 1, value)
             )
         ret[key] = value
         ret_swapped[value] = key
@@ -630,7 +720,7 @@ def _parse_wc2utt(file, swap, return_swap):
 
 
 def ctm_to_torch_token_data_dir(args=None):
-    '''Convert a NIST "ctm" file to a SpectDataSet token data dir
+    """Convert a NIST "ctm" file to a SpectDataSet token data dir
 
     A "ctm" file is a transcription file with token alignments (a.k.a. a
     time-marked conversation file) used in the `sclite
@@ -651,17 +741,17 @@ def ctm_to_torch_token_data_dir(args=None):
     :func:`get_torch_spect_data_dir_info` (command line
     "get-torch-spect-data-dir-info") for more information on a
     :class:`pydrobert.torch.data.SpectDataSet`
-    '''
+    """
     try:
         options = _ctm_to_torch_token_data_dir_parse_args(args)
     except SystemExit as ex:
         return ex.code
-    token2id = _parse_token2id(
-        options.token2id, options.swap, options.swap)
+    token2id = _parse_token2id(options.token2id, options.swap, options.swap)
     if options.unk_symbol is not None and options.unk_symbol not in token2id:
         print(
             'Unk symbol "{}" is not in token2id'.format(options.unk_symbol),
-            file=sys.stderr)
+            file=sys.stderr,
+        )
         return 1
     if options.wc2utt:
         wc2utt = _parse_wc2utt(options.wc2utt, False, False)
@@ -671,65 +761,84 @@ def ctm_to_torch_token_data_dir(args=None):
         wc2utt = None
     transcripts = data.read_ctm(options.ctm, wc2utt)
     _save_transcripts_to_dir(
-        transcripts, token2id, options.file_prefix, options.file_suffix,
-        options.dir, options.frame_shift_ms, options.unk_symbol)
+        transcripts,
+        token2id,
+        options.file_prefix,
+        options.file_suffix,
+        options.dir,
+        options.frame_shift_ms,
+        options.unk_symbol,
+    )
     return 0
 
 
 def _torch_token_data_dir_to_ctm_parse_args(args):
-    parser = argparse.ArgumentParser(
-        description=torch_token_data_dir_to_ctm.__doc__)
+    parser = argparse.ArgumentParser(description=torch_token_data_dir_to_ctm.__doc__)
+    parser.add_argument("dir", help="The directory to read token sequences from")
     parser.add_argument(
-        'dir', help='The directory to read token sequences from')
-    parser.add_argument(
-        'id2token', type=argparse.FileType('r'),
-        help='A file containing mappings from unique IDs to tokens (e.g. '
-        'words or phones). Each line has the format ``<id> <token>``. The '
-        '``--swap`` can be used to swap the expected ordering (i.e. '
-        '``<token> <id>``)'
+        "id2token",
+        type=argparse.FileType("r"),
+        help="A file containing mappings from unique IDs to tokens (e.g. "
+        "words or phones). Each line has the format ``<id> <token>``. The "
+        "``--swap`` can be used to swap the expected ordering (i.e. "
+        "``<token> <id>``)",
     )
     parser.add_argument(
-        'ctm', type=argparse.FileType('w'),
-        help='The "ctm" file to write token segments to')
-    parser.add_argument(
-        '--file-prefix', default='',
-        help='The file prefix indicating a torch data file'
+        "ctm",
+        type=argparse.FileType("w"),
+        help='The "ctm" file to write token segments to',
     )
     parser.add_argument(
-        '--file-suffix', default='.pt',
-        help='The file suffix indicating a torch data file'
+        "--file-prefix", default="", help="The file prefix indicating a torch data file"
     )
     parser.add_argument(
-        '--swap', action='store_true', default=False,
-        help='If set, swaps the order of key and value in `id2token`'
+        "--file-suffix",
+        default=".pt",
+        help="The file suffix indicating a torch data file",
     )
     parser.add_argument(
-        '--frame-shift-ms', type=int, default=10,
-        help='The number of milliseconds that have passed between consecutive '
-        'frames. Used to convert between time in seconds and frame index'
+        "--swap",
+        action="store_true",
+        default=False,
+        help="If set, swaps the order of key and value in `id2token`",
+    )
+    parser.add_argument(
+        "--frame-shift-ms",
+        type=float,
+        default=10.0,
+        help="The number of milliseconds that have passed between consecutive "
+        "frames. Used to convert between time in seconds and frame index. If your "
+        "features are the raw samples, set this to 1000 / sample_rate_hz",
     )
     utt_group = parser.add_mutually_exclusive_group()
     utt_group.add_argument(
-        '--wc2utt', type=argparse.FileType('r'), default=None,
-        help='A file mapping wavefile name and channel combinations (e.g. '
-        '``utt_1 A``) to utterance IDs. Each line of the file has the format '
-        '``<wavefile_name> <channel> <utt_id>``')
+        "--wc2utt",
+        type=argparse.FileType("r"),
+        default=None,
+        help="A file mapping wavefile name and channel combinations (e.g. "
+        "``utt_1 A``) to utterance IDs. Each line of the file has the format "
+        "``<wavefile_name> <channel> <utt_id>``",
+    )
     utt_group.add_argument(
-        '--utt2wc', type=argparse.FileType('r'), default=None,
-        help='A file mapping utterance IDs to wavefile name and channel '
-        'combinations (e.g. ``utt_1 A``). Each line of the file has the '
-        'format ``<utt_id> <wavefile_name> <channel>``')
+        "--utt2wc",
+        type=argparse.FileType("r"),
+        default=None,
+        help="A file mapping utterance IDs to wavefile name and channel "
+        "combinations (e.g. ``utt_1 A``). Each line of the file has the "
+        "format ``<utt_id> <wavefile_name> <channel>``",
+    )
     utt_group.add_argument(
-        '--channel', default='A',
+        "--channel",
+        default="A",
         help='If neither "--wc2utt" nor "--utt2wc" is specified, utterance '
-        'IDs are treated as wavefile names and are given the value of this '
-        'flag as a channel'
+        "IDs are treated as wavefile names and are given the value of this "
+        "flag as a channel",
     )
     return parser.parse_args(args)
 
 
 def torch_token_data_dir_to_ctm(args=None):
-    '''Convert a SpectDataSet token data directory to a NIST "ctm" file
+    """Convert a SpectDataSet token data directory to a NIST "ctm" file
 
     A "ctm" file is a transcription file with token alignments (a.k.a. a
     time-marked conversation file) used in the `sclite
@@ -751,13 +860,12 @@ def torch_token_data_dir_to_ctm(args=None):
     file. See the command :func:`get_torch_spect_data_dir_info` (command line
     "get-torch-spect-data-dir-info") for more information on a
     :class:`pydrobert.torch.data.SpectDataSet`
-    '''
+    """
     try:
         options = _torch_token_data_dir_to_ctm_parse_args(args)
     except SystemExit as ex:
         return ex.code
-    id2token = _parse_token2id(
-        options.id2token, not options.swap, options.swap)
+    id2token = _parse_token2id(options.id2token, not options.swap, options.swap)
     if options.wc2utt:
         utt2wc = _parse_wc2utt(options.wc2utt, False, True)
     elif options.utt2wc:
@@ -765,104 +873,133 @@ def torch_token_data_dir_to_ctm(args=None):
     else:
         utt2wc = options.channel
     transcripts = _load_transcripts_from_data_dir(
-        options.dir, id2token, options.file_prefix, options.file_suffix,
-        options.frame_shift_ms)
+        options.dir,
+        id2token,
+        options.file_prefix,
+        options.file_suffix,
+        options.frame_shift_ms,
+    )
     data.write_ctm(transcripts, options.ctm, utt2wc)
     return 0
 
 
 def _compute_torch_token_data_dir_parse_args(args):
     parser = argparse.ArgumentParser(
-        description=compute_torch_token_data_dir_error_rates.__doc__)
-    parser.add_argument(
-        'dir', help='If the `hyp` argument is not specified, this is the '
-        'parent directory of two subdirectories, ``ref/`` and ``hyp/``, which '
-        'contain the reference and hypothesis transcripts, respectively. If '
-        'the ``--hyp`` argument is specified, this is the reference '
-        'transcript directory'
+        description=compute_torch_token_data_dir_error_rates.__doc__
     )
     parser.add_argument(
-        'hyp', nargs='?', default=None,
-        help='The hypothesis transcript directory',
+        "dir",
+        help="If the `hyp` argument is not specified, this is the "
+        "parent directory of two subdirectories, ``ref/`` and ``hyp/``, which "
+        "contain the reference and hypothesis transcripts, respectively. If "
+        "the ``--hyp`` argument is specified, this is the reference "
+        "transcript directory",
     )
     parser.add_argument(
-        'out', nargs='?', type=argparse.FileType('w'), default=sys.stdout,
-        help='Where to print the error rate to. Defaults to stdout',
+        "hyp", nargs="?", default=None, help="The hypothesis transcript directory",
     )
     parser.add_argument(
-        '--id2token', type=argparse.FileType('r'), default=None,
-        help='A file containing mappings from unique IDs to tokens (e.g. '
-        'words or phones). Each line has the format ``<id> <token>``. The '
-        '``--swap`` flag can be used to swap the expected ordering (i.e. '
-        '``<token> <id>``). ``--id2token`` can be used to collapse unique IDs '
-        'together. Also, ``--ignore`` will contain a list of strings instead '
-        'of IDs'
+        "out",
+        nargs="?",
+        type=argparse.FileType("w"),
+        default=sys.stdout,
+        help="Where to print the error rate to. Defaults to stdout",
     )
     parser.add_argument(
-        '--replace', type=argparse.FileType('r'), default=None,
-        help='A file containing pairs of elements per line. The first is the '
-        'element to replace, the second what to replace it with. If '
-        '``--id2token`` is specified, the file should contain tokens. If '
-        '``--id2token`` is not specified, the file should contain IDs '
-        '(integers). This is processed before ``--ignore``'
+        "--id2token",
+        type=argparse.FileType("r"),
+        default=None,
+        help="A file containing mappings from unique IDs to tokens (e.g. "
+        "words or phones). Each line has the format ``<id> <token>``. The "
+        "``--swap`` flag can be used to swap the expected ordering (i.e. "
+        "``<token> <id>``). ``--id2token`` can be used to collapse unique IDs "
+        "together. Also, ``--ignore`` will contain a list of strings instead "
+        "of IDs",
     )
     parser.add_argument(
-        '--ignore', type=argparse.FileType('r'), default=None,
-        help='A file containing a whitespace-delimited list of elements to '
-        'ignore in both the reference and hypothesis transcripts. If '
-        '``--id2token`` is specified, the file should contain tokens. If '
-        '``--id2token`` is not specified, the file should contain IDs '
-        '(integers). This is processed after ``--replace``'
+        "--replace",
+        type=argparse.FileType("r"),
+        default=None,
+        help="A file containing pairs of elements per line. The first is the "
+        "element to replace, the second what to replace it with. If "
+        "``--id2token`` is specified, the file should contain tokens. If "
+        "``--id2token`` is not specified, the file should contain IDs "
+        "(integers). This is processed before ``--ignore``",
     )
     parser.add_argument(
-        '--file-prefix', default='',
-        help='The file prefix indicating a torch data file'
+        "--ignore",
+        type=argparse.FileType("r"),
+        default=None,
+        help="A file containing a whitespace-delimited list of elements to "
+        "ignore in both the reference and hypothesis transcripts. If "
+        "``--id2token`` is specified, the file should contain tokens. If "
+        "``--id2token`` is not specified, the file should contain IDs "
+        "(integers). This is processed after ``--replace``",
     )
     parser.add_argument(
-        '--file-suffix', default='.pt',
-        help='The file suffix indicating a torch data file'
+        "--file-prefix", default="", help="The file prefix indicating a torch data file"
     )
     parser.add_argument(
-        '--swap', action='store_true', default=False,
-        help='If set, swaps the order of key and value in `id2token`'
+        "--file-suffix",
+        default=".pt",
+        help="The file suffix indicating a torch data file",
     )
     parser.add_argument(
-        '--warn-missing', action='store_true', default=False,
-        help='If set, warn and exclude any utterances that are missing either '
-        'a reference or hypothesis transcript. The default is to error'
+        "--swap",
+        action="store_true",
+        default=False,
+        help="If set, swaps the order of key and value in `id2token`",
     )
     parser.add_argument(
-        '--distances', action='store_true', default=False,
-        help='If set, do not normalize by reference lengths'
+        "--warn-missing",
+        action="store_true",
+        default=False,
+        help="If set, warn and exclude any utterances that are missing either "
+        "a reference or hypothesis transcript. The default is to error",
     )
     parser.add_argument(
-        '--per-utt', action='store_true', default=False,
-        help='If set, return lines of ``<utt_id> <error_rate>`` denoting the '
-        'per-utterance error rates instead of the average'
+        "--distances",
+        action="store_true",
+        default=False,
+        help="If set, do not normalize by reference lengths",
     )
     parser.add_argument(
-        '--ins-cost', type=float, default=1.,
-        help='The cost of an adding a superfluous token to a hypothesis '
-        'transcript',
+        "--per-utt",
+        action="store_true",
+        default=False,
+        help="If set, return lines of ``<utt_id> <error_rate>`` denoting the "
+        "per-utterance error rates instead of the average",
     )
     parser.add_argument(
-        '--del-cost', type=float, default=1.,
-        help='The cost of missing a token from a reference transcript',
+        "--ins-cost",
+        type=float,
+        default=1.0,
+        help="The cost of an adding a superfluous token to a hypothesis " "transcript",
     )
     parser.add_argument(
-        '--sub-cost', type=float, default=1.,
-        help='The cost of swapping a reference token with a hypothesis token',
+        "--del-cost",
+        type=float,
+        default=1.0,
+        help="The cost of missing a token from a reference transcript",
     )
     parser.add_argument(
-        '--batch-size', type=int, default=100,
-        help='The number of error rates to compute at once. Reduce if you '
-        'run into memory errors'
+        "--sub-cost",
+        type=float,
+        default=1.0,
+        help="The cost of swapping a reference token with a hypothesis token",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="The number of error rates to compute at once. Reduce if you "
+        "run into memory errors",
     )
     return parser.parse_args(args)
 
 
 def compute_torch_token_data_dir_error_rates(args=None):
-    '''Compute error rates between reference and hypothesis token data dirs
+    """Compute error rates between reference and hypothesis token data dirs
 
     This is a very simple script that computes and prints the error rates
     between the ``ref/`` (reference/gold standard) token sequences and ``hyp/``
@@ -879,7 +1016,7 @@ def compute_torch_token_data_dir_error_rates(args=None):
     Many tasks will ignore some tokens (e.g. silences) or collapse others (e.g.
     phones). Please consult a standard recipe (such as those in `Kaldi
     <http://kaldi-asr.org/>`__) before performing these computations
-    '''
+    """
     try:
         options = _compute_torch_token_data_dir_parse_args(args)
     except SystemExit as ex:
@@ -887,8 +1024,8 @@ def compute_torch_token_data_dir_error_rates(args=None):
     if options.hyp:
         ref_dir, hyp_dir = options.dir, options.hyp
     else:
-        ref_dir = os.path.join(options.dir, 'ref')
-        hyp_dir = os.path.join(options.dir, 'hyp')
+        ref_dir = os.path.join(options.dir, "ref")
+        hyp_dir = os.path.join(options.dir, "hyp")
     if not os.path.isdir(ref_dir):
         print('"{}" is not a directory'.format(ref_dir), file=sys.stderr)
         return 1
@@ -896,8 +1033,7 @@ def compute_torch_token_data_dir_error_rates(args=None):
         print('"{}" is not a directory'.format(hyp_dir), file=sys.stderr)
         return 1
     if options.id2token:
-        id2token = _parse_token2id(
-            options.id2token, not options.swap, options.swap)
+        id2token = _parse_token2id(options.id2token, not options.swap, options.swap)
     else:
         id2token = None
     replace = dict()
@@ -910,7 +1046,8 @@ def compute_torch_token_data_dir_error_rates(args=None):
                 except ValueError:
                     raise ValueError(
                         'If --id2token is not set, all elements in "{}" must '
-                        'be integers'.format(options.replace.name))
+                        "be integers".format(options.replace.name)
+                    )
             replace[replaced] = replacement
     if options.ignore:
         ignore = set(options.ignore.read().strip().split())
@@ -920,15 +1057,28 @@ def compute_torch_token_data_dir_error_rates(args=None):
             except ValueError:
                 raise ValueError(
                     'If --id2token is not set, all elements in "{}" must be '
-                    'integers'.format(options.ignore.name))
+                    "integers".format(options.ignore.name)
+                )
     else:
         ignore = set()
-    ref_transcripts = list(_load_transcripts_from_data_dir(
-        ref_dir, id2token, options.file_prefix, options.file_suffix,
-        strip_timing=True))
-    hyp_transcripts = list(_load_transcripts_from_data_dir(
-        hyp_dir, id2token, options.file_prefix, options.file_suffix,
-        strip_timing=True))
+    ref_transcripts = list(
+        _load_transcripts_from_data_dir(
+            ref_dir,
+            id2token,
+            options.file_prefix,
+            options.file_suffix,
+            strip_timing=True,
+        )
+    )
+    hyp_transcripts = list(
+        _load_transcripts_from_data_dir(
+            hyp_dir,
+            id2token,
+            options.file_prefix,
+            options.file_suffix,
+            strip_timing=True,
+        )
+    )
     idx = 0
     while idx < max(len(ref_transcripts), len(hyp_transcripts)):
         missing_ref = missing_hyp = False
@@ -949,10 +1099,10 @@ def compute_torch_token_data_dir_error_rates(args=None):
                 del ref_transcripts[idx]
             msg = (
                 'Directory "{}" contains utterance "{}" which directory "{}" '
-                'does not contain'
+                "does not contain"
             ).format(*fmt_tup)
             if options.warn_missing:
-                warnings.warn(msg + '. Skipping')
+                warnings.warn(msg + ". Skipping")
             else:
                 raise ValueError(msg)
         else:
@@ -968,41 +1118,53 @@ def compute_torch_token_data_dir_error_rates(args=None):
     token2id = defaultdict(get_idee)
     error_rates = OrderedDict()
     while len(ref_transcripts):
-        batch_ref_transcripts = ref_transcripts[:options.batch_size]
-        batch_hyp_transcripts = hyp_transcripts[:options.batch_size]
-        ref_transcripts = ref_transcripts[options.batch_size:]
-        hyp_transcripts = hyp_transcripts[options.batch_size:]
+        batch_ref_transcripts = ref_transcripts[: options.batch_size]
+        batch_hyp_transcripts = hyp_transcripts[: options.batch_size]
+        ref_transcripts = ref_transcripts[options.batch_size :]
+        hyp_transcripts = hyp_transcripts[options.batch_size :]
         ref = torch.nn.utils.rnn.pad_sequence(
             [
-                torch.tensor([
-                    token2id[replace.get(token, token)] for token in transcript
-                    if replace.get(token, token) not in ignore
-                ] + [eos])
+                torch.tensor(
+                    [
+                        token2id[replace.get(token, token)]
+                        for token in transcript
+                        if replace.get(token, token) not in ignore
+                    ]
+                    + [eos]
+                )
                 for _, transcript in batch_ref_transcripts
             ],
             padding_value=padding,
         )
         hyp = torch.nn.utils.rnn.pad_sequence(
             [
-                torch.tensor([
-                    token2id[replace.get(token, token)] for token in transcript
-                    if replace.get(token, token) not in ignore
-                ] + [eos])
+                torch.tensor(
+                    [
+                        token2id[replace.get(token, token)]
+                        for token in transcript
+                        if replace.get(token, token) not in ignore
+                    ]
+                    + [eos]
+                )
                 for _, transcript in batch_hyp_transcripts
             ],
             padding_value=padding,
         )
         ers = util.error_rate(
-            ref, hyp, eos=eos, include_eos=False, ins_cost=options.ins_cost,
-            del_cost=options.del_cost, sub_cost=options.sub_cost,
+            ref,
+            hyp,
+            eos=eos,
+            include_eos=False,
+            ins_cost=options.ins_cost,
+            del_cost=options.del_cost,
+            sub_cost=options.sub_cost,
             norm=not options.distances,
         )
         for (utt_id, _), er in zip(batch_ref_transcripts, ers):
             error_rates[utt_id] = er.item()
     if options.per_utt:
         for utt_id, er in error_rates.items():
-            options.out.write('{} {}\n'.format(utt_id, er))
+            options.out.write("{} {}\n".format(utt_id, er))
     else:
-        options.out.write('{}\n'.format(
-            sum(error_rates.values()) / len(error_rates)))
+        options.out.write("{}\n".format(sum(error_rates.values()) / len(error_rates)))
     return 0

--- a/pydrobert/torch/data.py
+++ b/pydrobert/torch/data.py
@@ -987,7 +987,7 @@ def transcript_to_token(
     ----------
     transcript : sequence
     token2id : dict, optional
-    frame_shift_ms : int, optional
+    frame_shift_ms : float, optional
     unk : str or int, optional
         If not :obj:`None`, specifies the out-of-vocabulary token. If `unk`
         exists in `token2id`, the ``token2id[unk]`` will be used as the
@@ -1001,6 +1001,12 @@ def transcript_to_token(
     Returns
     -------
     tok : torch.LongTensor
+
+    Notes
+    -----
+    If you are dealing with raw audio, each "frame" is just a sample. The appropriate
+    value for `frame_shift_ms` is ``1000 / sample_rate_hz`` (since there are
+    ``sample_rate_hz / 1000`` samples per millisecond).
     """
     if token2id is not None and unk in token2id:
         unk = token2id[unk]
@@ -1043,7 +1049,7 @@ def token_to_transcript(tok, id2token=None, frame_shift_ms=None):
         Either of shape ``(R, 3)`` with segmentation info or ``(R, 1)`` or
         ``(R,)`` without
     id2token : dict, optional
-    frame_shift_ms : int, optional
+    frame_shift_ms : float, optional
 
     Returns
     -------

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -299,7 +299,7 @@ def test_torch_token_data_dir_to_ctm(temp_dir, tokens, channels, frame_shift_ms)
 @pytest.mark.parametrize("per_utt", [True, False])
 @pytest.mark.parametrize(
     "tokens,collapse_vowels",
-    [("token2id", False), ("id2token", True), ("id2token", False), (None, False),],
+    [("token2id", False), ("id2token", True), ("id2token", False), (None, False)],
 )
 @pytest.mark.parametrize("norm", [False])
 def test_compute_torch_token_data_dir_error_rates(

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -18,94 +18,95 @@ __copyright__ = "Copyright 2018 Sean Robertson"
 @pytest.mark.cpu
 def test_get_torch_spect_data_dir_info(temp_dir, populate_torch_dir):
     _, alis, _, feat_sizes, _, _ = populate_torch_dir(
-        temp_dir, 19, num_filts=5, max_class=10)
+        temp_dir, 19, num_filts=5, max_class=10
+    )
     # add one with class idx 10 to ensure all classes are accounted for
-    torch.save(torch.rand(1, 5), os.path.join(temp_dir, 'feat', 'utt19.pt'))
-    torch.save(torch.tensor([10]), os.path.join(temp_dir, 'ali', 'utt19.pt'))
-    torch.save(
-        torch.tensor([[100, 0, 1]]), os.path.join(temp_dir, 'ref', 'utt19.pt'))
+    torch.save(torch.rand(1, 5), os.path.join(temp_dir, "feat", "utt19.pt"))
+    torch.save(torch.tensor([10]), os.path.join(temp_dir, "ali", "utt19.pt"))
+    torch.save(torch.tensor([[100, 0, 1]]), os.path.join(temp_dir, "ref", "utt19.pt"))
     feat_sizes += (1,)
     alis = torch.cat(alis + [torch.tensor([10])])
     alis = [class_idx.item() for class_idx in alis]
-    table_path = os.path.join(temp_dir, 'info')
+    table_path = os.path.join(temp_dir, "info")
     assert not command_line.get_torch_spect_data_dir_info(
-        [temp_dir, table_path, '--strict'])
+        [temp_dir, table_path, "--strict"]
+    )
     table = dict()
     with open(table_path) as table_file:
         for line in table_file:
             line = line.split()
             table[line[0]] = int(line[1])
-    assert table['num_utterances'] == 20
-    assert table['total_frames'] == sum(feat_sizes)
-    assert table['num_filts'] == 5
-    assert table['max_ali_class'] == 10
-    assert table['max_ref_class'] == 100
+    assert table["num_utterances"] == 20
+    assert table["total_frames"] == sum(feat_sizes)
+    assert table["num_filts"] == 5
+    assert table["max_ali_class"] == 10
+    assert table["max_ref_class"] == 100
     for class_idx in range(11):
-        key = 'count_{:02d}'.format(class_idx)
+        key = "count_{:02d}".format(class_idx)
         assert table[key] == alis.count(class_idx)
     # ensure we're only looking at the ids in the recorded refs
-    torch.save(
-        torch.tensor([[100, 0, 101]]),
-        os.path.join(temp_dir, 'ref', 'utt19.pt'))
-    assert not command_line.get_torch_spect_data_dir_info(
-        [temp_dir, table_path])
+    torch.save(torch.tensor([[100, 0, 101]]), os.path.join(temp_dir, "ref", "utt19.pt"))
+    assert not command_line.get_torch_spect_data_dir_info([temp_dir, table_path])
     table = dict()
     with open(table_path) as table_file:
         for line in table_file:
             line = line.split()
             table[line[0]] = int(line[1])
-    assert table['max_ref_class'] == 100
+    assert table["max_ref_class"] == 100
     # invalidate the data set and try again
-    torch.save(torch.rand(1, 4), os.path.join(temp_dir, 'feat', 'utt19.pt'))
+    torch.save(torch.rand(1, 4), os.path.join(temp_dir, "feat", "utt19.pt"))
     with pytest.raises(ValueError):
-        command_line.get_torch_spect_data_dir_info(
-            [temp_dir, table_path, '--strict'])
+        command_line.get_torch_spect_data_dir_info([temp_dir, table_path, "--strict"])
 
 
 def _write_token2id(path, swap, collapse_vowels=False):
-    vowels = {ord(x) for x in 'aeiou'}
-    with open(path, 'w') as f:
-        for v in range(ord('a'), ord('z') + 1):
+    vowels = {ord(x) for x in "aeiou"}
+    with open(path, "w") as f:
+        for v in range(ord("a"), ord("z") + 1):
             if swap:
                 if collapse_vowels and v in vowels:
-                    f.write('{} a\n'.format(v - ord('a')))
+                    f.write("{} a\n".format(v - ord("a")))
                 else:
-                    f.write('{} {}\n'.format(v - ord('a'), chr(v)))
+                    f.write("{} {}\n".format(v - ord("a"), chr(v)))
             else:
                 assert not collapse_vowels
-                f.write('{} {}\n'.format(chr(v), v - ord('a')))
+                f.write("{} {}\n".format(chr(v), v - ord("a")))
 
 
 @pytest.mark.cpu
-@pytest.mark.parametrize('tokens', ['token2id', 'id2token'])
-@pytest.mark.parametrize('skip_frame_times,feat_sizing', [
-    (True, False),
-    (False, True),
-    (False, False)])
-def test_trn_to_torch_token_data_dir(
-        temp_dir, tokens, skip_frame_times, feat_sizing):
-    trn_path = os.path.join(temp_dir, 'ref.trn')
-    tokens_path = os.path.join(temp_dir, 'token2id')
-    ref_dir = os.path.join(temp_dir, 'ref')
-    _write_token2id(tokens_path, tokens == 'id2token')
-    with open(trn_path, 'w') as trn:
-        trn.write('''\
+@pytest.mark.parametrize("tokens", ["token2id", "id2token"])
+@pytest.mark.parametrize(
+    "skip_frame_times,feat_sizing", [(True, False), (False, True), (False, False)]
+)
+def test_trn_to_torch_token_data_dir(temp_dir, tokens, skip_frame_times, feat_sizing):
+    trn_path = os.path.join(temp_dir, "ref.trn")
+    tokens_path = os.path.join(temp_dir, "token2id")
+    ref_dir = os.path.join(temp_dir, "ref")
+    _write_token2id(tokens_path, tokens == "id2token")
+    with open(trn_path, "w") as trn:
+        trn.write(
+            """\
 a b b c (utt1)
 (utt2)
 
 d { e / f } g (utt3)
 {{{h / i} / j} / k} (utt4)
 A a (utt5)
-''')
+"""
+        )
     with warnings.catch_warnings(record=True):
         assert not command_line.trn_to_torch_token_data_dir(
             [
-                trn_path, tokens_path, ref_dir,
-                '--alt-handler=first', '--unk-symbol=c',
-                '--chunk-size=1'] +
-            (['--swap'] if tokens == 'id2token' else []) +
-            (['--skip-frame-times'] if skip_frame_times else []) +
-            (['--feat-sizing'] if feat_sizing else [])
+                trn_path,
+                tokens_path,
+                ref_dir,
+                "--alt-handler=first",
+                "--unk-symbol=c",
+                "--chunk-size=1",
+            ]
+            + (["--swap"] if tokens == "id2token" else [])
+            + (["--skip-frame-times"] if skip_frame_times else [])
+            + (["--feat-sizing"] if feat_sizing else [])
         )
     exp_utt1 = torch.tensor([0, 1, 1, 2])
     exp_utt3 = torch.tensor([3, 4, 6])
@@ -122,35 +123,35 @@ A a (utt5)
         exp_utt3 = torch.cat([exp_utt3.unsqueeze(-1), neg1_tensor[:3]], -1)
         exp_utt4 = torch.cat([exp_utt4.unsqueeze(-1), neg1_tensor[:1]], -1)
         exp_utt5 = torch.cat([exp_utt5.unsqueeze(-1), neg1_tensor[:2]], -1)
-    act_utt1 = torch.load(os.path.join(ref_dir, 'utt1.pt'))
+    act_utt1 = torch.load(os.path.join(ref_dir, "utt1.pt"))
     assert exp_utt1.shape == act_utt1.shape
     assert torch.all(act_utt1 == exp_utt1)
-    act_utt2 = torch.load(os.path.join(ref_dir, 'utt2.pt'))
+    act_utt2 = torch.load(os.path.join(ref_dir, "utt2.pt"))
     assert not act_utt2.numel()
-    act_utt3 = torch.load(os.path.join(ref_dir, 'utt3.pt'))
+    act_utt3 = torch.load(os.path.join(ref_dir, "utt3.pt"))
     assert exp_utt3.shape == act_utt3.shape
     assert torch.all(act_utt3 == exp_utt3)
-    act_utt4 = torch.load(os.path.join(ref_dir, 'utt4.pt'))
+    act_utt4 = torch.load(os.path.join(ref_dir, "utt4.pt"))
     assert exp_utt4.shape == act_utt4.shape
     assert torch.all(act_utt4 == exp_utt4)
-    act_utt5 = torch.load(os.path.join(ref_dir, 'utt5.pt'))
+    act_utt5 = torch.load(os.path.join(ref_dir, "utt5.pt"))
     assert exp_utt5.shape == act_utt5.shape
     assert torch.all(act_utt5 == exp_utt5)
 
 
 @pytest.mark.cpu
-@pytest.mark.parametrize('tokens', ['token2id', 'id2token'])
-@pytest.mark.parametrize('include_frame_shift', [True, False])
+@pytest.mark.parametrize("tokens", ["token2id", "id2token"])
+@pytest.mark.parametrize("include_frame_shift", [True, False])
 def test_torch_token_data_dir_to_trn(temp_dir, tokens, include_frame_shift):
     torch.manual_seed(1000)
     num_utts = 100
     max_tokens = 10
     num_digits = torch.log10(torch.tensor(float(num_utts))).long().item() + 1
-    utt_fmt = 'utt{{:0{}d}}'.format(num_digits)
-    trn_path = os.path.join(temp_dir, 'ref.trn')
-    tokens_path = os.path.join(temp_dir, 'id2token')
-    ref_dir = os.path.join(temp_dir, 'ref')
-    _write_token2id(tokens_path, tokens == 'id2token')
+    utt_fmt = "utt{{:0{}d}}".format(num_digits)
+    trn_path = os.path.join(temp_dir, "ref.trn")
+    tokens_path = os.path.join(temp_dir, "id2token")
+    ref_dir = os.path.join(temp_dir, "ref")
+    _write_token2id(tokens_path, tokens == "id2token")
     if not os.path.isdir(ref_dir):
         os.makedirs(ref_dir)
     exps = []
@@ -162,15 +163,14 @@ def test_torch_token_data_dir_to_trn(temp_dir, tokens, include_frame_shift):
             tok = torch.stack([ids] + ([torch.full_like(ids, -1)] * 2), -1)
         else:
             tok = ids
-        torch.save(tok, os.path.join(ref_dir, utt_id + '.pt'))
-        transcript = ' '.join([chr(x + ord('a')) for x in ids.tolist()])
-        transcript += ' ({})'.format(utt_id)
+        torch.save(tok, os.path.join(ref_dir, utt_id + ".pt"))
+        transcript = " ".join([chr(x + ord("a")) for x in ids.tolist()])
+        transcript += " ({})".format(utt_id)
         exps.append(transcript)
     assert not command_line.torch_token_data_dir_to_trn(
-        [ref_dir, tokens_path, trn_path] +
-        (['--swap'] if tokens == 'token2id' else [])
+        [ref_dir, tokens_path, trn_path] + (["--swap"] if tokens == "token2id" else [])
     )
-    with open(trn_path, 'r') as trn:
+    with open(trn_path, "r") as trn:
         acts = trn.readlines()
     assert len(exps) == len(acts)
     for exp, act in zip(exps, acts):
@@ -179,29 +179,30 @@ def test_torch_token_data_dir_to_trn(temp_dir, tokens, include_frame_shift):
 
 def _write_wc2utt(path, swap, chan, num_utts):
     num_digits = torch.log10(torch.tensor(float(num_utts))).long().item() + 1
-    idx_fmt = '{{0:0{}d}}'.format(num_digits)
+    idx_fmt = "{{0:0{}d}}".format(num_digits)
     if swap:
-        fmt = 'u_{0} w_{0} {{1}}\n'.format(idx_fmt)
+        fmt = "u_{0} w_{0} {{1}}\n".format(idx_fmt)
     else:
-        fmt = 'w_{0} {{1}} u_{0}\n'.format(idx_fmt)
-    with open(path, 'w') as f:
+        fmt = "w_{0} {{1}} u_{0}\n".format(idx_fmt)
+    with open(path, "w") as f:
         for utt_idx in range(num_utts):
             f.write(fmt.format(utt_idx, chan))
 
 
 @pytest.mark.cpu
-@pytest.mark.parametrize('tokens', ['token2id', 'id2token'])
-@pytest.mark.parametrize('channels', ['wc2utt', 'utt2wc', None])
+@pytest.mark.parametrize("tokens", ["token2id", "id2token"])
+@pytest.mark.parametrize("channels", ["wc2utt", "utt2wc", None])
 def test_ctm_to_torch_token_data_dir(temp_dir, tokens, channels):
-    ctm_path = os.path.join(temp_dir, 'ref.ctm')
+    ctm_path = os.path.join(temp_dir, "ref.ctm")
     tokens_path = os.path.join(temp_dir, tokens)
     channels_path = os.path.join(temp_dir, channels) if channels else None
-    ref_dir = os.path.join(temp_dir, 'ref')
-    _write_token2id(tokens_path, tokens == 'id2token')
+    ref_dir = os.path.join(temp_dir, "ref")
+    _write_token2id(tokens_path, tokens == "id2token")
     if channels:
-        _write_wc2utt(channels_path, channels == 'utt2wc', 'A', 5)
-    with open(ctm_path, 'w') as ctm:
-        ctm.write('''\
+        _write_wc2utt(channels_path, channels == "utt2wc", "A", 5)
+    with open(ctm_path, "w") as ctm:
+        ctm.write(
+            """\
 ;; some text
 w_1 A 0.1 1.0 a
 
@@ -212,50 +213,46 @@ w_3 A 0.0 1000.0 d
 w_3 A 1.0 0.1 d
 w_4 A 0.0 2.0 Z
 w_4 A 0.1 1.1 a
-''')
-    args = [ctm_path, tokens_path, ref_dir, '--unk-symbol=a']
-    if tokens == 'id2token':
-        args.append('--swap')
-    if channels == 'utt2wc':
-        args.append('--utt2wc={}'.format(channels_path))
-    elif channels == 'wc2utt':
-        args.append('--wc2utt={}'.format(channels_path))
+"""
+        )
+    args = [ctm_path, tokens_path, ref_dir, "--unk-symbol=a"]
+    if tokens == "id2token":
+        args.append("--swap")
+    if channels == "utt2wc":
+        args.append("--utt2wc={}".format(channels_path))
+    elif channels == "wc2utt":
+        args.append("--wc2utt={}".format(channels_path))
     assert not command_line.ctm_to_torch_token_data_dir(args)
-    act_utt1 = torch.load(
-        os.path.join(ref_dir, 'u_1.pt' if channels else 'w_1.pt'))
-    assert torch.all(act_utt1 == torch.tensor([
-        [0, 10, 110], [1, 20, 120], [2, 30, 130]]))
-    act_utt2 = torch.load(
-        os.path.join(ref_dir, 'u_2.pt' if channels else 'w_2.pt'))
+    act_utt1 = torch.load(os.path.join(ref_dir, "u_1.pt" if channels else "w_1.pt"))
+    assert torch.all(
+        act_utt1 == torch.tensor([[0, 10, 110], [1, 20, 120], [2, 30, 130]])
+    )
+    act_utt2 = torch.load(os.path.join(ref_dir, "u_2.pt" if channels else "w_2.pt"))
     assert torch.all(act_utt2 == torch.tensor([[1, 0, 0]]))
-    act_utt3 = torch.load(
-        os.path.join(ref_dir, 'u_3.pt' if channels else 'w_3.pt'))
-    assert torch.all(act_utt3 == torch.tensor([
-        [3, 0, 100000], [3, 100, 110]]))
-    act_utt4 = torch.load(
-        os.path.join(ref_dir, 'u_4.pt' if channels else 'w_4.pt'))
-    assert torch.all(act_utt4 == torch.tensor(
-        [[0, 0, 200], [0, 10, 120]]))
+    act_utt3 = torch.load(os.path.join(ref_dir, "u_3.pt" if channels else "w_3.pt"))
+    assert torch.all(act_utt3 == torch.tensor([[3, 0, 100000], [3, 100, 110]]))
+    act_utt4 = torch.load(os.path.join(ref_dir, "u_4.pt" if channels else "w_4.pt"))
+    assert torch.all(act_utt4 == torch.tensor([[0, 0, 200], [0, 10, 120]]))
 
 
 @pytest.mark.cpu
-@pytest.mark.parametrize('tokens', ['token2id', 'id2token'])
-@pytest.mark.parametrize('channels', ['wc2utt', 'utt2wc', None])
-def test_torch_token_data_dir_to_ctm(temp_dir, tokens, channels):
+@pytest.mark.parametrize("tokens", ["token2id", "id2token"])
+@pytest.mark.parametrize("channels", ["wc2utt", "utt2wc", None])
+@pytest.mark.parametrize("frame_shift_ms", [20.0, 0.1])
+def test_torch_token_data_dir_to_ctm(temp_dir, tokens, channels, frame_shift_ms):
     torch.manual_seed(420)
-    ctm_path = os.path.join(temp_dir, 'ref.ctm')
+    ctm_path = os.path.join(temp_dir, "ref.ctm")
     tokens_path = os.path.join(temp_dir, tokens)
     channels_path = os.path.join(temp_dir, channels) if channels else None
-    ref_dir = os.path.join(temp_dir, 'ref')
+    ref_dir = os.path.join(temp_dir, "ref")
     num_utts, max_tokens, max_start, max_dur = 100, 10, 1000, 100
     max_tokens = 10
-    frame_shift_ms = 20
     num_digits = torch.log10(torch.tensor(float(num_utts))).long().item() + 1
-    utt_fmt = 'u_{{:0{}d}}'.format(num_digits)
-    wfn_fmt = '{}_{{:0{}d}}'.format('w' if channels else 'u', num_digits)
-    _write_token2id(tokens_path, tokens == 'id2token')
+    utt_fmt = "u_{{:0{}d}}".format(num_digits)
+    wfn_fmt = "{}_{{:0{}d}}".format("w" if channels else "u", num_digits)
+    _write_token2id(tokens_path, tokens == "id2token")
     if channels:
-        _write_wc2utt(channels_path, channels == 'utt2wc', 'A', num_utts)
+        _write_wc2utt(channels_path, channels == "utt2wc", "A", num_utts)
     if not os.path.isdir(ref_dir):
         os.makedirs(ref_dir)
     exps = []
@@ -268,23 +265,29 @@ def test_torch_token_data_dir_to_ctm(temp_dir, tokens, channels):
         durs = torch.randint(max_dur, (num_tokens,)).long()
         ends = starts + durs
         tok = torch.stack([ids, starts, ends], -1)
-        torch.save(tok, os.path.join(ref_dir, utt_id + '.pt'))
+        torch.save(tok, os.path.join(ref_dir, utt_id + ".pt"))
         for token, start, end in sorted(tok.tolist(), key=lambda x: x[1:]):
             start = start * frame_shift_ms / 1000
             end = end * frame_shift_ms / 1000
-            exps.append('{} A {} {} {}'.format(
-                wfn_id, start, end - start, chr(token + ord('a'))))
+            exps.append(
+                "{} A {} {} {}".format(
+                    wfn_id, start, end - start, chr(token + ord("a"))
+                )
+            )
     args = [
-        ref_dir, tokens_path, ctm_path,
-        '--frame-shift-ms={}'.format(frame_shift_ms)]
-    if tokens == 'token2id':
-        args.append('--swap')
-    if channels == 'utt2wc':
-        args.append('--utt2wc={}'.format(channels_path))
-    elif channels == 'wc2utt':
-        args.append('--wc2utt={}'.format(channels_path))
+        ref_dir,
+        tokens_path,
+        ctm_path,
+        "--frame-shift-ms={}".format(frame_shift_ms),
+    ]
+    if tokens == "token2id":
+        args.append("--swap")
+    if channels == "utt2wc":
+        args.append("--utt2wc={}".format(channels_path))
+    elif channels == "wc2utt":
+        args.append("--wc2utt={}".format(channels_path))
     assert not command_line.torch_token_data_dir_to_ctm(args)
-    with open(ctm_path, 'r') as ctm:
+    with open(ctm_path, "r") as ctm:
         acts = ctm.readlines()
     assert len(exps) == len(acts)
     for exp, act in zip(exps, acts):
@@ -294,60 +297,61 @@ def test_torch_token_data_dir_to_ctm(temp_dir, tokens, channels):
 @pytest.mark.cpu
 @pytest.mark.filterwarnings("ignore")
 @pytest.mark.parametrize("per_utt", [True, False])
-@pytest.mark.parametrize('tokens,collapse_vowels', [
-    ('token2id', False),
-    ('id2token', True),
-    ('id2token', False),
-    (None, False),
-])
-@pytest.mark.parametrize('norm', [False])
+@pytest.mark.parametrize(
+    "tokens,collapse_vowels",
+    [("token2id", False), ("id2token", True), ("id2token", False), (None, False),],
+)
+@pytest.mark.parametrize("norm", [False])
 def test_compute_torch_token_data_dir_error_rates(
-        temp_dir, per_utt, tokens, collapse_vowels, norm):
+    temp_dir, per_utt, tokens, collapse_vowels, norm
+):
     torch.manual_seed(3820)
-    tokens_path = os.path.join(temp_dir, 'map')
-    ignore_path = os.path.join(temp_dir, 'ignore')
-    replace_path = os.path.join(temp_dir, 'replace')
-    out_path = os.path.join(temp_dir, 'out')
-    ref_dir = os.path.join(temp_dir, 'ref')
-    hyp_dir = os.path.join(temp_dir, 'hyp')
+    tokens_path = os.path.join(temp_dir, "map")
+    ignore_path = os.path.join(temp_dir, "ignore")
+    replace_path = os.path.join(temp_dir, "replace")
+    out_path = os.path.join(temp_dir, "out")
+    ref_dir = os.path.join(temp_dir, "ref")
+    hyp_dir = os.path.join(temp_dir, "hyp")
     if not os.path.isdir(ref_dir):
         os.makedirs(ref_dir)
     if not os.path.isdir(hyp_dir):
         os.makedirs(hyp_dir)
     num_elem = 40
-    missing_prob = .1
+    missing_prob = 0.1
     max_fillers = 5
-    ignore_chars = '_#'
-    replace_chars = '*/'
-    with open(ignore_path, 'w') as f:
+    ignore_chars = "_#"
+    replace_chars = "*/"
+    with open(ignore_path, "w") as f:
         if tokens is None:
-            f.write(' '.join([str(ord(c) - ord('a')) for c in ignore_chars]))
+            f.write(" ".join([str(ord(c) - ord("a")) for c in ignore_chars]))
         else:
-            f.write(' '.join(ignore_chars))
+            f.write(" ".join(ignore_chars))
         f.flush()
-    with open(replace_path, 'w') as f:
+    with open(replace_path, "w") as f:
         for c in replace_chars:
             if tokens is None:
-                f.write('{} {}\n'.format(
-                    ord(c) - ord('a'), ord(ignore_chars[0]) - ord('a')))
+                f.write(
+                    "{} {}\n".format(ord(c) - ord("a"), ord(ignore_chars[0]) - ord("a"))
+                )
             else:
-                f.write('{} {}\n'.format(c, ignore_chars[0]))
+                f.write("{} {}\n".format(c, ignore_chars[0]))
     ignore_chars += replace_chars
     tuples = (
-        ('cat', 'bat', 1, 1),
-        ('transubstantiation', 'transwhatnow', 10, 10),
-        ('cool', 'coal', 1, 0),
-        ('zap', 'zippy', 3, 2),
+        ("cat", "bat", 1, 1),
+        ("transubstantiation", "transwhatnow", 10, 10),
+        ("cool", "coal", 1, 0),
+        ("zap", "zippy", 3, 2),
     )
     if tokens is not None:
         _write_token2id(
-            tokens_path, tokens == 'id2token', collapse_vowels=collapse_vowels)
-        with open(tokens_path, 'a') as f:
+            tokens_path, tokens == "id2token", collapse_vowels=collapse_vowels
+        )
+        with open(tokens_path, "a") as f:
             for c in ignore_chars:
-                if tokens == 'id2token':
-                    f.write('{} {}\n'.format(ord(c) - ord('a'), c))
+                if tokens == "id2token":
+                    f.write("{} {}\n".format(ord(c) - ord("a"), c))
                 else:
-                    f.write('{} {}\n'.format(c, ord(c) - ord('a')))
+                    f.write("{} {}\n".format(c, ord(c) - ord("a")))
     exp = dict()
     num_utt_ids = 0
     while len(exp) < num_elem:
@@ -362,20 +366,18 @@ def test_compute_torch_token_data_dir_error_rates(
         num_hyp_fillers = torch.randint(max_fillers, (1,)).item()
         for _ in range(num_ref_fillers):
             fill_idx = torch.randint(len(ref) + 1, (1,)).item()
-            filler = ignore_chars[
-                torch.randint(len(ignore_chars), (1,)).item()]
+            filler = ignore_chars[torch.randint(len(ignore_chars), (1,)).item()]
             ref = ref[:fill_idx] + filler + ref[fill_idx:]
         for _ in range(num_hyp_fillers):
             fill_idx = torch.randint(len(hyp) + 1, (1,)).item()
-            filler = ignore_chars[
-                torch.randint(len(ignore_chars), (1,)).item()]
+            filler = ignore_chars[torch.randint(len(ignore_chars), (1,)).item()]
             hyp = hyp[:fill_idx] + filler + hyp[fill_idx:]
-        ref = torch.tensor([(ord(c) - ord('a'), -1, -1) for c in ref])
-        hyp = torch.tensor([(ord(c) - ord('a'), -1, -1) for c in hyp])
+        ref = torch.tensor([(ord(c) - ord("a"), -1, -1) for c in ref])
+        hyp = torch.tensor([(ord(c) - ord("a"), -1, -1) for c in hyp])
         utt_id = num_utt_ids
         num_utt_ids += 1
-        ref_path = os.path.join(ref_dir, '{}.pt'.format(utt_id))
-        hyp_path = os.path.join(hyp_dir, '{}.pt'.format(utt_id))
+        ref_path = os.path.join(ref_dir, "{}.pt".format(utt_id))
+        hyp_path = os.path.join(hyp_dir, "{}.pt".format(utt_id))
         if torch.rand(1).item() < missing_prob:
             if torch.randint(2, (1,)).item():
                 torch.save(ref, ref_path)
@@ -385,18 +387,23 @@ def test_compute_torch_token_data_dir_error_rates(
         torch.save(hyp, hyp_path)
         exp[str(utt_id)] = er
     args = [
-        ref_dir, hyp_dir, out_path,
-        '--ignore', ignore_path, '--replace', replace_path,
-        '--warn-missing',
+        ref_dir,
+        hyp_dir,
+        out_path,
+        "--ignore",
+        ignore_path,
+        "--replace",
+        replace_path,
+        "--warn-missing",
     ]
     if not norm:
-        args.append('--distances')
+        args.append("--distances")
     if per_utt:
-        args.append('--per-utt')
+        args.append("--per-utt")
     if tokens is not None:
-        args += ['--id2token', tokens_path]
-        if tokens == 'token2id':
-            args.append('--swap')
+        args += ["--id2token", tokens_path]
+        if tokens == "token2id":
+            args.append("--swap")
     assert not command_line.compute_torch_token_data_dir_error_rates(args)
     if per_utt:
         with open(out_path) as f:


### PR DESCRIPTION
A few minor changes to allow for floating point frame shifts in CLI. This allows appropriate settings for raw audio (instead of filter bank features).

The Black code formatter also had a bit of fun.