### PR TITLE
CTM-related fixes/features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.3.1
+
+1. Modified frame end in `pydrobert.torch.data.transcript_to_token` and added
+   some notes on the ambiguity of the conversion.
+
 # v0.3.0
 
 A considerable amount of refactoring occurred for this build, chiefly to get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
-# v0.3.1
+# Change log
+
+## HEAD
 
 - Modified frame end in `pydrobert.torch.data.transcript_to_token` and added
   some notes on the ambiguity of the conversion.
 - Added some more checks and a 'fix' flag to
-  `pydrobert.torch.data.validate_spect_data_set`.
+  `pydrobert.torch.data.validate_spect_data_set`. Entry
+  `get-torch-spect-data-dir-info` now has `--fix` flag, too.
 
-# v0.3.0
+## v0.3.0
 
 A considerable amount of refactoring occurred for this build, chiefly to get
 rid of Python 2.7 support. While the functionality did not change much for this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # v0.3.1
 
-1. Modified frame end in `pydrobert.torch.data.transcript_to_token` and added
-   some notes on the ambiguity of the conversion.
+- Modified frame end in `pydrobert.torch.data.transcript_to_token` and added
+  some notes on the ambiguity of the conversion.
+- Added some more checks and a 'fix' flag to
+  `pydrobert.torch.data.validate_spect_data_set`.
 
 # v0.3.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ test:
     - pytest.ini
   requires:
     - pytest
-    - cudatoolkit
+    - pytorch * *cuda*
   imports:
     - pydrobert
     - pydrobert.torch

--- a/src/pydrobert/torch/command_line.py
+++ b/src/pydrobert/torch/command_line.py
@@ -51,13 +51,6 @@ def _get_torch_spect_data_dir_info_parse_args(args):
         help="The file to write to. If unspecified, stdout",
     )
     parser.add_argument(
-        "--strict",
-        action="store_true",
-        default=False,
-        help="If set, validate the data directory before collecting info. The "
-        "process is described in pydrobert.torch.data.validate_spect_data_set",
-    )
-    parser.add_argument(
         "--file-prefix", default="", help="The file prefix indicating a torch data file"
     )
     parser.add_argument(
@@ -76,6 +69,24 @@ def _get_torch_spect_data_dir_info_parse_args(args):
         default="ref",
         help="Subdirectory where reference token sequences are stored",
     )
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--strict",
+        action="store_true",
+        default=False,
+        help="If set, validate the data directory before collecting info. The "
+        "process is described in pydrobert.torch.data.validate_spect_data_set",
+    )
+    group.add_argument(
+        "--fix",
+        action="store_true",
+        default=False,
+        help="If set, validate the data directory before collecting info, potentially "
+        "fixing small errors in the directory. The process is described in "
+        "pydrobert.torch.validate_spect_data_set",
+    )
+
     return parser.parse_args(args)
 
 
@@ -144,8 +155,8 @@ def get_torch_spect_data_dir_info(args: Optional[Sequence[str]] = None) -> None:
         ali_subdir=options.ali_subdir,
         ref_subdir=options.ref_subdir,
     )
-    if options.strict:
-        data.validate_spect_data_set(data_set)
+    if options.strict or options.fix:
+        data.validate_spect_data_set(data_set, options.fix)
     info_dict = {
         "num_utterances": len(data_set),
         "total_frames": 0,

--- a/src/pydrobert/torch/data.py
+++ b/src/pydrobert/torch/data.py
@@ -458,21 +458,22 @@ class SpectDataSet(torch.utils.data.Dataset):
         )
 
 
-def validate_spect_data_set(data_set: SpectDataSet) -> None:
+def validate_spect_data_set(data_set: SpectDataSet, fix: bool = False) -> None:
     """Validate SpectDataSet data directory
 
     The data directory is valid if the following conditions are observed
 
-    1. All features are tensor instances of the same dtype
-    2. All features have two axes
-    3. All features have the same size second axis
-    4. If alignments are present
+    1. All tensors are on the CPU
+    2. All features are tensor instances of the same dtype
+    3. All features have two dimensions
+    4. All features have the same size second dimension
+    5. If alignments are present
 
        1. All alignments are long tensor instances
-       2. All alignments have one axis
+       2. All alignments have one dimension
        3. Features and alignments have the same size first axes for a given utterance id
 
-    5. If reference sequences are present
+    6. If reference sequences are present
 
        1. All references are long tensor instances
        2. All alignments have the same number of dimensions: either 1 or 2
@@ -484,137 +485,172 @@ def validate_spect_data_set(data_set: SpectDataSet) -> None:
              r[i, 2] <= T``, where ``T`` is the number of frames in the utterance. We do
              not enforce that tokens be non-overlapping
 
-    Raises a :class:`ValueError` if a condition is violated
+    Raises a :class:`ValueError` if a condition is violated.
+
+    If `fix` is :obj:`True`, the following changes to the data will be permitted instead
+    of raising an error. Any of these changes will be warned of using :mod:`warnings`
+    and then written back to disk.
+
+    1. Any CUDA tensors will be converted into CPU tensors
+    2. A reference or alignment of bytes or 32-bit integers can be upcast to long
+       tensors.
+    3. A reference token with only a start or end bound (but not both) will have the
+       existing one removed.
+    5. A reference token with an exclusive boundary exceeding the number of features by
+       one will be decreased by one. This is only possible if the exclusive end
+       remains above the inclusive start.
     """
     num_filts = None
     ref_is_2d = None
     feat_dtype = None
     for idx in range(len(data_set.utt_ids)):
+        fn = data_set.utt_ids[idx] + data_set.file_suffix
         feat, ali, ref = data_set.get_utterance_tuple(idx)
+        write_back = False
+        prefix = "'{}' (index {})".format(fn, idx)
+        dir_ = os.path.join(data_set.data_dir, data_set.feat_subdir)
+        prefix_ = "{} in '{}'".format(prefix, dir_)
         if not isinstance(feat, torch.Tensor) or feat_dtype not in {None, feat.dtype}:
             raise ValueError(
-                "'{}' (index {}) in '{}' is not a tensor or not the same "
-                "tensor type as previous features".format(
-                    data_set.utt_ids[idx] + data_set.file_suffix,
-                    idx,
-                    os.path.join(data_set.data_dir, data_set.feat_subdir),
-                )
+                "{} is not a tensor or not the same tensor type as previous features"
+                "".format(prefix_)
             )
+        if feat.device.type == "cuda":
+            msg = "{} is a cuda tensor".format(prefix_)
+            if fix:
+                warnings.warn(msg)
+                feat = feat.cpu()
+                write_back = True
+            else:
+                raise ValueError(msg)
         feat_dtype = feat.dtype
-        if len(feat.size()) != 2:
-            raise ValueError(
-                "'{}' (index {}) in '{}' does not have two axes".format(
-                    data_set.utt_ids[idx] + data_set.file_suffix,
-                    idx,
-                    os.path.join(data_set.data_dir, data_set.feat_subdir),
-                )
-            )
+        if feat.dim() != 2:
+            raise ValueError("{} does not have two dimensions".format(prefix_))
         if num_filts is None:
-            num_filts = feat.shape[1]
-        elif feat.shape[1] != num_filts:
+            num_filts = feat.size(1)
+        elif feat.size(1) != num_filts:
             raise ValueError(
-                "'{}' (index {}) in '{}' has second axis size {}, which "
+                "{} has second dimension of size {}, which "
                 "does not match prior utterance ('{}') size of {}".format(
-                    data_set.utt_ids[idx] + data_set.file_suffix,
-                    idx,
-                    os.path.join(data_set.data_dir, data_set.feat_subdir),
-                    feat.shape[1],
+                    prefix_,
+                    feat.size(1),
                     data_set.utt_ids[idx - 1] + data_set.file_suffix,
                     num_filts,
                 )
             )
+        if write_back:
+            torch.save(feat, os.path.join(dir_, fn))
+            write_back = False
         if ali is not None:
+            dir_ = os.path.join(data_set.data_dir, data_set.ali_subdir)
+            prefix_ = "{} in '{}'".format(prefix, dir_)
+            if isinstance(ali, torch.Tensor) and ali.device.type == "cuda":
+                msg = "{} is a cuda tensor".format(prefix_)
+                if fix:
+                    warnings.warn(msg + ". Converting")
+                    ali = ali.cpu()
+                    write_back = True
+                else:
+                    raise ValueError(msg)
             if not isinstance(ali, torch.LongTensor):
-                raise ValueError(
-                    "'{}' (index {}) in '{}' is not a long tensor".format(
-                        data_set.utt_ids[idx] + data_set.file_suffix,
-                        idx,
-                        os.path.join(data_set.data_dir, data_set.ali_subdir),
-                    )
-                )
+                msg = "{} is not a long tensor".format(prefix_)
+                if fix and isinstance(
+                    ali,
+                    (
+                        torch.ByteTensor,
+                        torch.CharTensor,
+                        torch.ShortTensor,
+                        torch.IntTensor,
+                    ),
+                ):
+                    warnings.warn(msg + ". Converting")
+                    ali = ali.long()
+                    write_back = True
+                else:
+                    raise ValueError(msg)
             if len(ali.shape) != 1:
-                raise ValueError(
-                    "'{}' (index {}) in '{}' does not have one axis".format(
-                        data_set.utt_ids[idx] + data_set.file_suffix,
-                        idx,
-                        os.path.join(data_set.data_dir, data_set.ali_subdir),
-                    )
-                )
+                raise ValueError("{} does not have one dimension".format(prefix_))
             if ali.shape[0] != feat.shape[0]:
                 raise ValueError(
-                    "'{}' (index {}) in '{}' does not have the same first axis"
-                    " size ({}) as it's companion in '{}' ({})".format(
-                        data_set.utt_ids[idx] + data_set.file_suffix,
-                        idx,
-                        os.path.join(data_set.data_dir, data_set.feat_subdir),
+                    "{} does not have the same first dimension of"
+                    " size ({}) as its companion in '{}' ({})".format(
+                        prefix_,
                         feat.shape[0],
                         os.path.join(data_set.data_dir, data_set.ali_subdir),
                         ali.shape[0],
                     )
                 )
+            if write_back:
+                torch.save(ali, os.path.join(dir_, fn))
+                write_back = False
         if ref is not None:
+            dir_ = os.path.join(data_set.data_dir, data_set.ref_subdir)
+            prefix_ = "{} in '{}'".format(prefix, dir_)
+            if isinstance(ref, torch.Tensor) and ref.device.type == "cuda":
+                msg = "{} is a cuda tensor".format(prefix_)
+                if fix:
+                    warnings.warn(msg + ". Converting")
+                    ref = ref.cpu()
+                    write_back = True
+                else:
+                    raise ValueError(msg)
             if not isinstance(ref, torch.LongTensor):
-                raise ValueError(
-                    "'{}' (index {}) in '{}' is not a long tensor".format(
-                        data_set.utt_ids[idx] + data_set.file_suffix,
-                        idx,
-                        os.path.join(data_set.data_dir, data_set.ref_subdir),
-                    )
-                )
-            if len(ref.shape) == 2:
+                msg = "{} is not a long tensor".format(prefix_)
+                if fix and isinstance(
+                    ref,
+                    (
+                        torch.ByteTensor,
+                        torch.CharTensor,
+                        torch.ShortTensor,
+                        torch.IntTensor,
+                    ),
+                ):
+                    warnings.warn(msg + ". Converting")
+                    ref = ref.long()
+                    write_back = True
+                else:
+                    raise ValueError(msg)
+            if ref.dim() == 2:
                 if ref_is_2d is False:
                     raise ValueError(
-                        "'{}' (index {}) in '{}' is 2D. Previous "
-                        "transcriptions were 1D".format(
-                            data_set.utt_ids[idx] + data_set.file_suffix,
-                            idx,
-                            os.path.join(data_set.data_dir, data_set.ref_subdir),
-                        )
+                        "{} is 2D. Previous transcriptions were 1D".format(prefix_)
                     )
                 ref_is_2d = True
-                if ref.shape[1] != 3:
-                    raise ValueError(
-                        "'{}' (index {}) in '{}' does not have shape (D, 3)"
-                        "".format(
-                            data_set.utt_ids[idx] + data_set.file_suffix,
-                            idx,
-                            os.path.join(data_set.data_dir, data_set.ref_subdir),
-                        )
-                    )
+                if ref.size(1) != 3:
+                    raise ValueError("{} does not have shape (D, 3)".format(prefix_))
                 for idx2, r in enumerate(ref):
-                    if not (r[1] < 0 and r[2] < 0) and not (
-                        0 <= r[1] < r[2] <= feat.shape[0]
-                    ):
-                        raise ValueError(
-                            "'{}' (index {}) in '{}', has a reference token "
-                            "(index {}) with invalid boundaries"
-                            "".format(
-                                data_set.utt_ids[idx] + data_set.file_suffix,
-                                idx,
-                                os.path.join(data_set.data_dir, data_set.ref_subdir),
-                                idx2,
-                            )
-                        )
-            elif len(ref.shape) == 1:
+                    msg = (
+                        "{} has a reference token (index {}) with invalid boundaries"
+                        "".format(prefix_, idx2)
+                    )
+                    if not (r[1] < 0 and r[2] < 0):
+                        if r[1] < 0 or r[2] < 0:
+                            if fix:
+                                warnings.warn(msg + ". Removing unpaired boundary")
+                                r[1:] = -1
+                                write_back = True
+                            else:
+                                raise ValueError(msg)
+                        elif r[2] > feat.size(0):
+                            if fix and r[2] - 1 == feat.size(0) and r[1] < r[2] - 1:
+                                warnings.warn(msg + ". Reducing upper bound by 1")
+                                r[2] -= 1
+                                write_back = True
+                            else:
+                                raise ValueError(msg)
+                        elif r[1] >= r[2]:
+                            raise ValueError(msg)
+
+            elif ref.dim() == 1:
                 if ref_is_2d is True:
                     raise ValueError(
-                        "'{}' (index {}) in '{}' is 1D. Previous "
-                        "transcriptions were 2D".format(
-                            data_set.utt_ids[idx] + data_set.file_suffix,
-                            idx,
-                            os.path.join(data_set.data_dir, data_set.ref_subdir),
-                        )
+                        "{} is 1D. Previous transcriptions were 2D".format(prefix_)
                     )
                 ref_is_2d = False
             else:
-                raise ValueError(
-                    "'{}' (index {}) in '{}' is not 1D nor 2D"
-                    "".format(
-                        data_set.utt_ids[idx] + data_set.file_suffix,
-                        idx,
-                        os.path.join(data_set.data_dir, data_set.ref_subdir),
-                    )
-                )
+                raise ValueError("{} is not 1D nor 2D".format(prefix_))
+            if write_back:
+                torch.save(ref, os.path.join(dir_, fn))
 
 
 class _AltTree(object):

--- a/src/pydrobert/torch/data.py
+++ b/src/pydrobert/torch/data.py
@@ -39,15 +39,6 @@ import torch.utils.data
 import param
 import pydrobert.torch
 
-try:
-    str
-except NameError:
-    str = str
-
-__author__ = "Sean Robertson"
-__email__ = "sdrobert@cs.toronto.edu"
-__license__ = "Apache 2.0"
-__copyright__ = "Copyright 2019 Sean Robertson"
 __all__ = [
     "context_window_seq_to_batch",
     "ContextWindowDataParams",
@@ -986,7 +977,7 @@ def transcript_to_token(
     unk: Optional[Union[str, int]] = None,
     skip_frame_times: bool = False,
 ) -> torch.Tensor:
-    """Convert a transcript to a token sequence
+    r"""Convert a transcript to a token sequence
 
     This method converts `transcript` of length ``R`` to a long tensor `tok` of shape
     ``(R, 3)``, the latter suitable as a reference or hypothesis token sequence for an
@@ -1000,13 +991,13 @@ def transcript_to_token(
     times, in seconds, of the token, and will be converted to frames for `tok`. If
     `frame_shift_ms` is unspecified, ``start`` and ``end`` are assumed to already be
     frame times. If ``start`` and ``end`` were unspecified, values of ``-1``,
-    representing unknown, will be inserted into ``r[i, 1:]``
+    representing unknown, will be inserted into ``tok[r, 1:]``
 
     Parameters
     ----------
     transcript : sequence
     token2id : dict, optional
-    frame_shift_ms : float, optional
+    frame_shift_ms : float or None, optional
     unk : str or int, optional
         If not :obj:`None`, specifies the out-of-vocabulary token. If `unk`
         exists in `token2id`, the ``token2id[unk]`` will be used as the
@@ -1021,11 +1012,48 @@ def transcript_to_token(
     -------
     tok : torch.Tensor
 
+    Warnings
+    --------
+    The frame index bounds inferred using `frame_shift_ms` should not be used directly
+    in evaluation. See the below note.
+
     Notes
     -----
     If you are dealing with raw audio, each "frame" is just a sample. The appropriate
     value for `frame_shift_ms` is ``1000 / sample_rate_hz`` (since there are
     ``sample_rate_hz / 1000`` samples per millisecond).
+
+    Converting to frame indices from start and end times follows an overly-simplistic
+    equation. Letting :math:`(s_s, e_s)` be the start and end times in seconds,
+    :math:`(s_f, e_f)` be the corresponding start and end frames, :math:`\Delta` be
+    the frame shift in milliseconds, and :math:`I[\cdot]` be the indicator function.
+    Then
+
+    .. math::
+
+        s_f = floor\left(\frac{1000s_s}{\Delta}\right) \\
+        e_f = \max\left(s_s + I[s_s = e_s],
+                        round\left(\frac{1000e_s}{\Delta}\right)\right)
+
+    For a given token index, ``tok[r, 1] = s_f`` and ``tok[r, 2] = e_f``. ``tok[r, 1]``
+    is supposed to be the inclusive start frame of the segment and ``tok[r, 2]`` the
+    exclusive end frame. :math:`(s_f, e_f)` fail to be these on two accounts. First,
+    they do not consider the frame length. First, while frames may be spaced
+    :math:`\Delta` milliseconds apart, they will usually be overlapping. Because of this
+    overlap, the coefficients of frames :math:`s_f - 1` and :math:`e_f` may be in part
+    dependent on the audio samples within the segment. Second, ignoring frame length,
+    :frac:`e_f = ceil(1000e_s/\Delta)` would be more appropriate for an exclusive upper
+    bound. However, :mod:`pydrobert.speech.compute` (and other, mainstream feature
+    computation packages), the total number of frames in the utterance is calculated as
+    :math:`T_f = ceil(1000T_s/\Delta)`, where :math:`T_s` is the length of the utterance
+    in seconds. The above equation ensures :math:`\max(e_f) \leq T_f`, which is a
+    neccessary criterion for a valid :class:`SpectDataSet` (see
+    :func:`validate_spec_data_set`).
+
+    Accounting for both of these assumptions would involve computing the support of
+    each existing frame in seconds and intersecting that with the provided interval in
+    seconds. As such, the derived frame bounds should not be used for an official
+    evaluation. This function should suffice for most training objectives, however.
     """
     if token2id is not None and unk in token2id:
         unk = token2id[unk]
@@ -1039,9 +1067,14 @@ def transcript_to_token(
             if len(token) == 3 and np.isreal(token[1]) and np.isreal(token[2]):
                 token, start, end = token
                 if frame_shift_ms:
-                    start = (1000 * start) / frame_shift_ms
-                    end = (1000 * end) / frame_shift_ms
-                start, end = int(start), int(end)
+                    if start == end:
+                        start = end = (1000 * start) // frame_shift_ms
+                    else:
+                        start = (1000 * start) // frame_shift_ms
+                        end = (1000 * end + 0.5 * frame_shift_ms) // frame_shift_ms
+                        end = max(end, start + 1)
+                else:
+                    start, end = int(start), int(end)
         except TypeError:
             pass
         if token2id is None:
@@ -1077,6 +1110,12 @@ def token_to_transcript(
     Returns
     -------
     token : list
+
+    Warnings
+    --------
+    The time interval inferred using `frame_shift_ms` is unlikely to be perfectly
+    correct. See the note in :func:`transcript_to_token` for more details about the
+    ambiguity in converting between seconds and frames.
     """
     transcript = []
     for tup in tok:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -234,34 +234,85 @@ def test_spect_data_set_validity(temp_dir, eos):
     with pytest.raises(ValueError, match="not the same tensor type"):
         data.validate_spect_data_set(data_set)
     torch.save(torch.rand(4,), feats_b_pt)
-    with pytest.raises(ValueError, match="does not have two axes"):
+    with pytest.raises(ValueError, match="does not have two dimensions"):
         data.validate_spect_data_set(data_set)
     torch.save(torch.rand(4, 3), feats_b_pt)
-    with pytest.raises(ValueError, match="has second axis size 3.*"):
+    with pytest.raises(ValueError, match="has second dimension of size 3.*"):
         data.validate_spect_data_set(data_set)
     torch.save(torch.rand(4, 4), feats_b_pt)
     data.validate_spect_data_set(data_set)
     torch.save(torch.randint(10, (4,)).int(), ali_b_pt)
     with pytest.raises(ValueError, match="is not a long tensor"):
         data.validate_spect_data_set(data_set)
+    with pytest.warns(UserWarning):
+        data.validate_spect_data_set(data_set, True)  # will fix bad type
+    data.validate_spect_data_set(data_set)  # fine after correction
     torch.save(torch.randint(10, (4, 1), dtype=torch.long), ali_b_pt)
-    with pytest.raises(ValueError, match="does not have one axis"):
+    with pytest.raises(ValueError, match="does not have one dimension"):
         data.validate_spect_data_set(data_set)
     torch.save(torch.randint(10, (3,), dtype=torch.long), ali_b_pt)
     with pytest.raises(ValueError, match="does not have the same first"):
         data.validate_spect_data_set(data_set)
     torch.save(torch.randint(10, (4,), dtype=torch.long), ali_b_pt)
     data.validate_spect_data_set(data_set)
+    torch.save(torch.Tensor([[0, 1, 2]]).int(), ref_b_pt)
+    with pytest.raises(ValueError, match="is not a long tensor"):
+        data.validate_spect_data_set(data_set)
+    with pytest.warns(UserWarning):
+        data.validate_spect_data_set(data_set, True)  # convert to long
+    data.validate_spect_data_set(data_set)
     torch.save(torch.tensor([[0, -1, 2], [1, 1, 2]]), ref_b_pt)
     with pytest.raises(ValueError, match="invalid boundaries"):
         data.validate_spect_data_set(data_set)
-    torch.save(torch.tensor([[0, 0, 1], [1, 5, 30]]), ref_b_pt)
+    with pytest.warns(UserWarning):
+        data.validate_spect_data_set(data_set, True)  # will remove end bound
+    data.validate_spect_data_set(data_set)
+    torch.save(torch.tensor([[0, 0, 1], [1, 3, 5]]), ref_b_pt)
     with pytest.raises(ValueError, match="invalid boundaries"):
         data.validate_spect_data_set(data_set)
+    with pytest.warns(UserWarning):
+        data.validate_spect_data_set(data_set, True)  # will trim 5 to 4
+    data.validate_spect_data_set(data_set)
+    torch.save(torch.tensor([[0, 0, 1], [1, 4, 5]]), ref_b_pt)
+    with pytest.raises(ValueError, match="invalid boundaries"):
+        data.validate_spect_data_set(data_set, True)  # will not trim b/c causes s == e
     torch.save(torch.tensor([1, 2, 3]), ref_b_pt)
     with pytest.raises(ValueError, match="were 2D"):
         data.validate_spect_data_set(data_set)
     torch.save(torch.tensor([10, 4, 2, 5]), ref_a_pt)
+    data.validate_spect_data_set(data_set)
+
+
+@pytest.mark.gpu
+def test_validate_spect_data_set_cuda(temp_dir):
+    torch.manual_seed(29)
+    feat_dir = os.path.join(temp_dir, "feat")
+    ali_dir = os.path.join(temp_dir, "ali")
+    ref_dir = os.path.join(temp_dir, "ref")
+    feats_pt = os.path.join(feat_dir, "a.pt")
+    ali_pt = os.path.join(ali_dir, "a.pt")
+    ref_pt = os.path.join(ref_dir, "a.pt")
+    os.makedirs(feat_dir)
+    os.makedirs(ali_dir)
+    os.makedirs(ref_dir)
+    torch.save(torch.rand(10, 5), feats_pt)
+    torch.save(torch.randint(10, (10,), dtype=torch.long), ali_pt)
+    torch.save(torch.tensor([1, 2, 3]), ref_pt)
+    data_set = data.SpectDataSet(temp_dir)
+    data.validate_spect_data_set(data_set)
+    torch.save(torch.rand(10, 5).cuda(), feats_pt)
+    with pytest.raises(ValueError, match="cuda"):
+        data.validate_spect_data_set(data_set)
+    with pytest.warns(UserWarning):
+        data.validate_spect_data_set(data_set, True)  # to CPU
+    data.validate_spect_data_set(data_set)
+    torch.save(torch.rand(10, 5).cuda(), feats_pt)
+    torch.save(torch.randint(10, (10,), dtype=torch.long).cuda(), ali_pt)
+    torch.save(torch.tensor([1, 2, 3]).cuda(), ref_pt)
+    with pytest.raises(ValueError, match="cuda"):
+        data.validate_spect_data_set(data_set)
+    with pytest.warns(UserWarning):
+        data.validate_spect_data_set(data_set, True)  # to CPU
     data.validate_spect_data_set(data_set)
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -484,18 +484,30 @@ def test_transcript_to_token(transcript, token2id, unk, skip_frame_times, exp):
 
 @pytest.mark.cpu
 def test_transcript_to_token_frame_shift():
-    trans = [(12, 0.5, 0.81), 420, (1, 2.1, 2.2)]
+    trans = [(12, 0.5, 0.81), 420, (1, 2.1, 2.2), (3, 2.8, 2.815), (12, 2.9, 3.0025)]
     # normal case: frame shift 10ms. Frame happens every hundredth of a second,
-    # so multiply by 100
+    # so multiply by 100. Half-frames should round up; quarter-frames down
     tok = data.transcript_to_token(trans, frame_shift_ms=10)
     assert torch.allclose(
-        tok, torch.LongTensor([[12, 50, 81], [420, -1, -1], [1, 210, 220]])
+        tok,
+        torch.LongTensor(
+            [[12, 50, 81], [420, -1, -1], [1, 210, 220], [3, 280, 282], [12, 290, 300]]
+        ),
     )
     # raw case @ 8000Hz sample rate. "Frame" is every sample. frames/msec =
     # 1000 / sample_rate_hz = 1 / 8.
     tok = data.transcript_to_token(trans, frame_shift_ms=1 / 8)
     assert torch.allclose(
-        tok, torch.LongTensor([[12, 4000, 6480], [420, -1, -1], [1, 16800, 17600]])
+        tok,
+        torch.LongTensor(
+            [
+                [12, 4000, 6480],
+                [420, -1, -1],
+                [1, 16800, 17600],
+                [3, 22400, 22520],
+                [12, 23200, 24020],
+            ]
+        ),
     )
 
 


### PR DESCRIPTION
This PR relates to my handling of segments (viz. CTM files) in the TIMIT corpus. I updated the logic of `transcript_to_token` and `validate_data_dir`. The latter also has an option to fix small errors, including those that might occur from the transition from times to frames.