### PR TITLE
pad_variable and RandomShift for padding variable-length batches

### DIFF
--- a/src/pydrobert/torch/layers.py
+++ b/src/pydrobert/torch/layers.py
@@ -41,6 +41,7 @@ __all__ = [
     "LookupLanguageModel",
     "MinimumErrorRateLoss",
     "MultiHeadedAttention",
+    "RandomShift",
     "SequentialLanguageModel",
     "SpecAugment",
 ]

--- a/src/pydrobert/torch/layers.py
+++ b/src/pydrobert/torch/layers.py
@@ -21,11 +21,16 @@ The loss functions :class:`HardOptimalCompletionDistillationLoss` and
 """
 
 import abc
-from typing import NoReturn, Optional, Sequence, Tuple
+from typing import NoReturn, Optional, Sequence, Tuple, Union
 
 import torch
 
-from pydrobert.torch.util import error_rate, optimal_completion, polyharmonic_spline
+from pydrobert.torch.util import (
+    error_rate,
+    optimal_completion,
+    polyharmonic_spline,
+    pad_variable,
+)
 
 __all__ = [
     "ConcatSoftAttention",
@@ -2156,3 +2161,123 @@ class SpecAugment(torch.nn.Module):
             lengths = torch.tensor([T] * N, device=feats.device)
         params = self.draw_parameters(feats, lengths)
         return self.apply_parameters(feats, params, lengths)
+
+
+class RandomShift(torch.nn.Module):
+    """Pad to the left and right of each sequence by a random amount
+
+    This layer is intended for training models which are robust to small shifts in some
+    variable-length sequence dimension (e.g. speech recognition). It pads each input
+    sequence with some number of elements at its beginning and end. The number of
+    elements is randomly chosen but bounded above by some proportion of the input length
+    specified by the user. Its call signature is
+
+        out, out_lens = layer(in_, in_lens)
+
+    Where: `in_` is a tensor of shape ``(N, T, *)`` where ``N`` is the batch dimension
+    and ``T`` is the sequence dimension; `in_lens` is a long tensor of shape ``(N,)``;
+    `out` is a tensor of the same type as `in_` of shape ``(N, T', *)``; and `out_lens`
+    is of shape ``(N,)``. The ``n``-th input sequence is stored in the range
+    ``in_[n, :in_lens[n]]``. The padded ``n``-th sequence is stored in the range
+    ``out[n, :out_lens[n]]``. Values outside of these ranges are undefined.
+
+    The amount of padding is dictated by the parameter `prop` this layer is initialized
+    with. A proportion is a non-negative float dictating the maximum ratio of the
+    original sequence length which may be padded, exclusive. `prop` can be a pair
+    ``left, right`` for separate ratios of padding at the beginning and end of a
+    sequence, or just one float if the proportions are the same. For example,
+    ``prop=0.5`` of a sequence of length ``10`` could result in a sequence of length
+    between ``10`` and ``18`` inclusive since each side of the sequence could be padded
+    with ``0-4`` elements (``0.5 * 10 = 5`` is an exclusive bound).
+
+    Padding is only applied if this layer is in training mode. If testing,
+    ``out, out_lens = in_, in_lens``.
+
+    Parameters
+    ----------
+    prop : float or tuple
+    mode : {'reflect', 'constant', 'replicate'}, optional
+        The method with which to pad the input sequence.
+    value : float, optional
+        The constant with which to pad the sequence if `mode` is set to
+        :obj:`'constant'`.
+
+    Attributes
+    ----------
+    mode : {'reflect', 'replicate', 'constant'}
+    prop : tuple
+    value : float
+
+    Raises
+    ------
+    NotImplementedError
+        On initialization if `mode` is :obj:`'reflect'` and a value in `prop` exceeds
+        ``1.0``. Reflection currently requires the amount of padding does not exceed
+        the original sequence length.
+
+    See Also
+    --------
+    pydrobert.torch.util.pad_variable
+        For more details on the different types of padding. Note the default `mode` is
+        different between this and the function.
+    """
+
+    def __init__(
+        self,
+        prop: Union[float, Tuple[float, float]],
+        mode: str = "reflect",
+        value: float = 0.0,
+    ):
+        super().__init__()
+        try:
+            prop = (float(prop), float(prop))
+        except TypeError:
+            prop = tuple(prop)
+        if len(prop) != 2:
+            raise ValueError(
+                f"prop must be a single or pair of floating points, got '{prop}'"
+            )
+        if prop[0] < 0.0 or prop[1] < 0.0:
+            raise ValueError("prop values must be non-negative")
+        if mode == "reflect":
+            if prop[0] > 1.0 or prop[1] > 1.0:
+                raise NotImplementedError(
+                    "if 'mode' is 'reflect', values in 'prop' must be <= 1"
+                )
+        elif mode not in {"constant", "replicate"}:
+            raise ValueError(
+                "'mode' must be one of 'reflect', 'constant', or 'replicate', got "
+                f"'{mode}'"
+            )
+        self.mode = mode
+        self.prop = prop
+        self.value = value
+
+    def extra_repr(self) -> str:
+        return f"prop={self.prop}, mode={self.mode}, value={self.value}"
+
+    def reset_parameters(self) -> None:
+        pass
+
+    def check_input(self, in_: torch.Tensor, in_lens: torch.Tensor) -> None:
+        if in_.dim() < 2:
+            raise RuntimeError(f"in_ must be at least 2 dimensional")
+        if in_lens.dim() != 1 or in_lens.size(0) != in_.size(0):
+            raise RuntimeError(
+                f"For in_ of shape {in_.shape}, expected in_lens to be of shape "
+                f"({in_.size(0)}), got {in_lens.shape}"
+            )
+
+    def forward(
+        self, in_: torch.Tensor, in_lens: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        self.check_input(in_, in_lens)
+        if self.training:
+            in_lens_ = in_lens.float()
+            pad = torch.stack([self.prop[0] * in_lens_, self.prop[1] * in_lens_])
+            pad *= torch.rand_like(pad)
+            pad = pad.long()
+            out_lens = in_lens + pad.sum(0)
+            return pad_variable(in_, in_lens, pad, self.mode, self.value), out_lens
+        else:
+            return in_, in_lens

--- a/src/pydrobert/torch/util.py
+++ b/src/pydrobert/torch/util.py
@@ -37,6 +37,7 @@ __all__ = [
     "edit_distance",
     "error_rate",
     "optimal_completion",
+    "pad_variable",
     "parse_arpa_lm",
     "polyharmonic_spline",
     "prefix_edit_distances",
@@ -1631,6 +1632,93 @@ def sparse_image_warp(
         )
 
         return warped
+
+
+def pad_variable(
+    x: torch.Tensor,
+    lens: torch.Tensor,
+    pad: torch.Tensor,
+    mode: str = "constant",
+    value: float = 0.0,
+) -> torch.Tensor:
+    """Pad variable-length input by a variable amount on each side
+
+    This function attempts to replicate the behaviour of :func:`torch.nn.functional.pad`
+    for `x` of variable sequence length with variable amounts of padding. `x` is a
+    tensor of shape ``(N, T, *)`` where ``N`` is the batch index and ``T`` is the
+    sequence index. `lens` is a long tensor of shape ``(N,)`` specifying the sequence
+    lengths: only the values in the range ``x[n, :lens[n]]`` are considered part of the
+    sequence of batch element ``n``. `pad` is a tensor of shape ``(2, N)`` specifying
+    how many elements at the start (``pad[0]``) and end (``pad[1]``) of each sequence.
+    The return tensor `padded` will have shape ``(N, T', *)`` such
+    that, for a given batch index ``n``,
+
+        padded[n, :pad[0, n]] = left padding
+        padded[n, pad[0,n]:pad[0,n] + lens[n]] = x[n, :lens[n]]
+        padded[n, pad[0,n] + lens[n]:pad[0,n] + lens[n] + pad[1, n]] = right padding
+
+    Parameters
+    ----------
+    x : torch.Tensor
+    lens : torch.Tensor
+    pad : torch.Tensor
+    mode : {'constant', 'reflect', 'replicate'}, optional
+        How to pad the sequences. :obj:`'constant'`: fill the padding region with the
+        value specified by `value`. :obj:`'reflect'`: padded values are reflections
+        around the endpoints. For example, the first right-padded value of the ``n``-th
+        sequence would be ``x[n, lens[n] - 2``, the third ``x[n, lens[n] - 3]``, and
+        so on. :obj:`replicate`: padding duplicates the endpoints of each sequence.
+        For example, the left-padded values of the ``n``-th sequence would all be
+        ``x[n, 0]``; the right-padded values would be ``x[n, lens[n] - 1]``.
+    value : scalar, optional
+        The value to pad with when ``mode == 'constant'``.
+
+    Returns
+    -------
+    padded : torch.Tensor
+        The new size for the second dimension would be
+        ``T' = (lens + pad.sum(0)).max().clamp_(min=T)``
+    """
+    old_shape = x.shape
+    ndim = len(old_shape)
+    if ndim < 2:
+        raise ValueError("Expected x to be at least two dimensional")
+    N, T = old_shape[:2]
+    if lens.shape != (N,):
+        raise ValueError(
+            f"For x of shape {old_shape}, lens should have shape ({N},) but got"
+            f"{lens.shape}"
+        )
+    if pad.shape != (2, N):
+        raise ValueError(
+            f"For x of shape {old_shape}, pad should have shape (2, {N}), but got "
+            f"{pad.shape}"
+        )
+    x = x.reshape(N, T, -1)
+    F = x.size(2)
+    new_lens = lens + pad.sum(0)
+    Tp = new_lens.max().clamp_(min=T)
+    arange_ = torch.arange(Tp, device=x.device)
+    if mode == "constant":
+        buff = torch.tensor(value, device=x.device, dtype=x.dtype).view(1)
+        left_pad = buff.expand(pad[0].sum() * F)
+        right_pad = buff.expand(pad[1].sum() * F)
+    else:
+        raise ValueError(
+            f"mode must be one of 'constant', 'reflect', 'replicate', got '{mode}'"
+        )
+    padded = torch.empty((N, Tp, F), device=x.device, dtype=x.dtype)
+    left_mask = (pad[0].unsqueeze(1) > arange_).unsqueeze(2)  # (N, Tp, 1)
+    padded = padded.masked_scatter(left_mask, left_pad)
+    mid_mask = ((pad[0] + lens).unsqueeze(1) > arange_).unsqueeze(2)  # (N, Tp, 1)
+    len_mask = (lens.unsqueeze(1) > arange_[:T]).unsqueeze(2)  # (N, T, 1)
+    x = x.masked_select(len_mask)
+    padded = padded.masked_scatter(mid_mask & ~left_mask, x)
+    right_mask = (new_lens.unsqueeze(1) > arange_).unsqueeze(2)  # (N, Tp, 1)
+    padded = padded.masked_scatter(right_mask & ~mid_mask, right_pad)
+    old_shape = list(old_shape)
+    old_shape[1] = Tp
+    return padded.view(*old_shape)
 
 
 def _deterimine_pinned_points(k, sizes):

--- a/src/pydrobert/torch/util.py
+++ b/src/pydrobert/torch/util.py
@@ -1686,6 +1686,34 @@ def pad_variable(
         ``mode == 'reflect'``
     RuntimeError
         If any element in `lens` is less than 1 when ``mode == 'replicate'``
+
+    Examples
+    --------
+
+    >>> x = torch.arange(10)
+    >>> x
+    tensor([[0, 1, 2, 3, 4],
+            [5, 6, 7, 8, 9]])
+    >>> lens = torch.tensor([3, 4])
+    >>> pad = torch.arange(4).view(2, 2)
+    >>> pad.t()  # [[0_left, 0_right], [1_left, 1_right]]
+    tensor([[0, 2],
+            [1, 3]])
+    >>> y = pad_variable(x, lens, pad)  # constant w/ value 0
+    >>> y[0, :3 + 0 + 2]
+    tensor([0, 1, 2, 0, 0])
+    >>> y[1, :4 + 1 + 3]
+    tensor([0, 5, 6, 7, 8, 0, 0, 0])
+    >>> y = pad_variable(x, lens, pad, 'reflect')
+    >>> y[0, :3 + 0 + 2]
+    tensor([0, 1, 2, 1, 0])
+    >>> y[1, :4 + 1 + 3]
+    tensor([6, 5, 6, 7, 8, 7, 6, 5])
+    >>> y = pad_variable(x, lens, pad, 'replicate')
+    >>> y[0, :3 + 0 + 2]
+    tensor([0, 1, 2, 2, 2])
+    >>> y[1, :4 + 1 + 3]
+    tensor([5, 5, 6, 7, 8, 8, 8, 8])
     """
     old_shape = x.shape
     ndim = len(old_shape)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,8 @@ def pytest_runtest_setup(item):
     if any(mark.name == "gpu" for mark in item.iter_markers()):
         if not CUDA_AVAIL:
             pytest.skip("cuda is not available")
+    # implicitly seeds all tests for the sake of reproducibility
+    torch.manual_seed(abs(hash(item.name)))
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -916,5 +916,21 @@ def test_spec_augment_call(device):
         max_time_mask_proportion=max_time_mask_proportion,
         num_time_mask=num_time_mask,
         num_freq_mask=num_freq_mask,
-    )
+    ).to(device)
     spec_augment(feats, lengths)
+
+
+@pytest.mark.parametrize("mode", ["reflect", "constant", "replicate"])
+def test_random_shift_call(device, mode):
+    torch.manual_seed(50)
+    N, T, A, B = 50, 300, 13, 11
+    in_ = torch.rand(N, T, A, B, device=device)
+    in_lens = torch.randint(1, T + 1, (N,), device=device)
+    rand_shift = layers.RandomShift(1.0, mode).to(device)
+    out, out_lens = rand_shift(in_, in_lens)
+    assert out.dim() == 4
+    assert (out_lens >= in_lens).all()
+    assert out.size(0) == N
+    assert out.size(1) >= out_lens.max()
+    assert out.size(2) == A
+    assert out.size(3) == B

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -791,3 +791,29 @@ def test_sparse_image_warp_matches_tensorflow(
     assert torch.allclose(exp_warped, act_warped, atol=1e-3), (
         (exp_warped - act_warped).abs().max()
     )
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "constant",
+        pytest.param("repeat", marks=pytest.mark.xfail),
+        pytest.param("replicate", marks=pytest.mark.xfail),
+    ],
+)
+def test_pad_variable(device, mode):
+    N, Tmax, Tmin, value = 10, 50, 5, -1
+    x = torch.rand((N, Tmax), device=device)
+    lens = torch.randint(Tmin, Tmax + 1, (N,), device=device)
+    pad = torch.randint(Tmin - 1, size=(2, N), device=device)
+    exp_padded = []
+    for x_n, lens_n, pad_n in zip(x, lens, pad.t()):
+        x_n = x_n[:lens_n]
+        padded_n = torch.nn.functional.pad(
+            x_n.unsqueeze(0).unsqueeze(0), pad_n.tolist(), mode, value
+        ).flatten()
+        exp_padded.append(padded_n)
+    act_padded = util.pad_variable(x, lens, pad, mode, value)
+    for exp_padded_n, act_padded_n in zip(exp_padded, act_padded):
+        assert torch.allclose(exp_padded_n, act_padded_n[: len(exp_padded_n)])
+

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -793,9 +793,7 @@ def test_sparse_image_warp_matches_tensorflow(
     )
 
 
-@pytest.mark.parametrize(
-    "mode", ["constant", "reflect", pytest.param("replicate", marks=pytest.mark.xfail)],
-)
+@pytest.mark.parametrize("mode", ["constant", "reflect", "replicate"])
 def test_pad_variable(device, mode):
     N, Tmax, Tmin = 10, 50, 5
     x = torch.rand((N, Tmax), device=device)
@@ -811,4 +809,6 @@ def test_pad_variable(device, mode):
     act_padded = util.pad_variable(x, lens, pad, mode)
     for exp_padded_n, act_padded_n in zip(exp_padded, act_padded):
         assert torch.allclose(exp_padded_n, act_padded_n[: len(exp_padded_n)])
-
+    # quick double-check that other types work
+    for type_ in (torch.long, torch.bool):
+        assert util.pad_variable(x.to(type_), lens, pad, mode).dtype == type_

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -794,15 +794,10 @@ def test_sparse_image_warp_matches_tensorflow(
 
 
 @pytest.mark.parametrize(
-    "mode",
-    [
-        "constant",
-        pytest.param("repeat", marks=pytest.mark.xfail),
-        pytest.param("replicate", marks=pytest.mark.xfail),
-    ],
+    "mode", ["constant", "reflect", pytest.param("replicate", marks=pytest.mark.xfail)],
 )
 def test_pad_variable(device, mode):
-    N, Tmax, Tmin, value = 10, 50, 5, -1
+    N, Tmax, Tmin = 10, 50, 5
     x = torch.rand((N, Tmax), device=device)
     lens = torch.randint(Tmin, Tmax + 1, (N,), device=device)
     pad = torch.randint(Tmin - 1, size=(2, N), device=device)
@@ -810,10 +805,10 @@ def test_pad_variable(device, mode):
     for x_n, lens_n, pad_n in zip(x, lens, pad.t()):
         x_n = x_n[:lens_n]
         padded_n = torch.nn.functional.pad(
-            x_n.unsqueeze(0).unsqueeze(0), pad_n.tolist(), mode, value
+            x_n.unsqueeze(0).unsqueeze(0), pad_n.tolist(), mode
         ).flatten()
         exp_padded.append(padded_n)
-    act_padded = util.pad_variable(x, lens, pad, mode, value)
+    act_padded = util.pad_variable(x, lens, pad, mode)
     for exp_padded_n, act_padded_n in zip(exp_padded, act_padded):
         assert torch.allclose(exp_padded_n, act_padded_n[: len(exp_padded_n)])
 


### PR DESCRIPTION
Pytorch does not have built-in support for padding variable-length tensors in `torch.nn.functional.pad`. This PR introduces this functionality into `pydrobert.torch.util.pad_variable`. In addition, `pydrobert.torch.layers.RandomShift` allows one to easily use this function for what I intended it for: data augmentation (random translations).