### PR TITLE
Added binomial_coefficient, enumerate_binary_sequences_with_cardinality, and SRSWOR enumerate_support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+- Added `binomial_coefficient` and
+  `enumerate_binary_sequences_with_cardinality`.
 - Docstrings updated to hopefully be clearer. Use "Call Parameters" and
   "Returns" sections for pytorch modules.
 - readthedocs updated.

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -5,6 +5,9 @@ References
    plans by using sequential (item by item) selection techniques and digital
    computers," vol. 57, no. 298, pp. 387-402, Jun. 1962, doi:
    10.1080/01621459.1962.10480667.
+.. [howard1972] S. Howard, "Discussion on Professor Cox's paper," Journal of
+   the Royal Statistical Society, vol. 34, no. 2, pp. 210-211, Jan. 1972, doi:
+   10.1111/j.2517-6161.1972.tb00900.x.
 .. [williams1992] R. J. Williams, "Simple statistical gradient-following
    algorithms for connectionist reinforcement learning," Machine Learning,
    vol. 8, no. 3, pp. 229-256, May 1992.

--- a/src/pydrobert/torch/_conditional_bernoulli.py
+++ b/src/pydrobert/torch/_conditional_bernoulli.py
@@ -147,6 +147,11 @@ def binomial_coefficient(length: torch.Tensor, count: torch.Tensor) -> torch.Ten
     will be avoided by ensuring `length` does not exceed :obj:`66`. The binomial
     coefficient is at its highest when ``count = length // 2`` and at its lowest when
     ``count == length`` or ``count == 0``.
+
+    Notes
+    -----
+    When the maximum `length` exceeds :obj:`20`, the implementation uses the recursion
+    defined in [howard1972]_.
     """
     device = length.device
     if ((count < 0) | (length < 0)).any():
@@ -167,7 +172,7 @@ def binomial_coefficient(length: torch.Tensor, count: torch.Tensor) -> torch.Ten
         count = count.clamp_max(length_)
         x = torch.arange(length_ + 2, device=device)
         x[0] = 1
-        x = x.cumprod_(0)
+        x = x.cumprod(0)
         binom = trunc_divide(x[length], x[count] * x[length_m_count])
         binom.masked_fill_(length_m_count == -1, 0)
     return binom

--- a/src/pydrobert/torch/functional.py
+++ b/src/pydrobert/torch/functional.py
@@ -14,7 +14,10 @@
 
 """Pytorch functions"""
 
-from ._conditional_bernoulli import simple_random_sampling_without_replacement
+from ._conditional_bernoulli import (
+    binomial_coefficient,
+    simple_random_sampling_without_replacement,
+)
 from ._decoding import (
     beam_search_advance,
     ctc_greedy_search,
@@ -47,6 +50,7 @@ from ._string import (
 
 __all__ = [
     "beam_search_advance",
+    "binomial_coefficient",
     "ctc_greedy_search",
     "ctc_prefix_search_advance",
     "dense_image_warp",

--- a/src/pydrobert/torch/functional.py
+++ b/src/pydrobert/torch/functional.py
@@ -16,6 +16,7 @@
 
 from ._conditional_bernoulli import (
     binomial_coefficient,
+    enumerate_binary_sequences_with_cardinality,
     simple_random_sampling_without_replacement,
 )
 from ._decoding import (
@@ -55,6 +56,7 @@ __all__ = [
     "ctc_prefix_search_advance",
     "dense_image_warp",
     "edit_distance",
+    "enumerate_binary_sequences_with_cardinality",
     "error_rate",
     "hard_optimal_completion_distillation_loss",
     "minimum_error_rate_loss",


### PR DESCRIPTION
A minor PR made mostly to handle SimpleRandomSamplingWithoutReplacement's enumerate_support method. In addition:

- pydrobert.torch.functional.binomial_coefficient
- pydrobert.torch.functional.enumerate_binary_sequences_with_cardinality