### PR TITLE
TrainingStateController automatically syncs with stored history less often

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Setup test suite
         run: tox -vv --notest
       - name: Run test suite
-        run: tox --skip-pkg-install
+        run: tox --skip-pkg-install -- tests/test_training.py

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Setup test suite
         run: tox -vv --notest
       - name: Run test suite
-        run: tox --skip-pkg-install -- tests/test_training.py
+        run: tox --skip-pkg-install

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,6 @@ python =
 [testenv]
 setenv =
     t151: PYTORCH_JIT = 0
-    OMP_NUM_THREADS = 1
-    MKL_NUM_THREADS = 1
 install_command = pip install --find-links https://download.pytorch.org/whl/cpu/torch_stable.html {opts} {packages}
 deps =
     pytest


### PR DESCRIPTION
This PR has to do with the frequency with which the training state controller updates its cache of training history.

Until now, the cache was updated automatically whenever the logic of the method could differ if the cache was state, e.g. `get_best_epoch`, `get_last_epoch`, or `get_info` when the epoch requested wasn't already in the cache. This makes sense if one views the in-memory store as an unreliable cache backed by disk.

However, this conceptualization is at best superfluous and at worst harmful. There is no need to check disk repeatedly so long as one assumes (rightfully) that the history is only being accessed by one training session at a time. Further, as #71 shows, checking the disk in a distributed environment can violate strong consistency unless aggressive barriers are employed before and after read.

This PR reduces the number of situations in which the cache is automatically updated to a) initialization of the controller; and b) the addition of a new entry (column) to the history. The user may still update the cache manually via `update_cache`.