### PR TITLE
Allow scientific notation log-probs in ARPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.4.0
 
+- `parse_arpa` can handle log-probs in scientific notation (e.g. `1e4`)
 - Added `best_is_train` flag to `TrainingController.update_for_epoch`
 - Refactored `get-torch-spect-data-dir-info` to be faster
 - `subset-torch-spect-data-dir` command has been added

--- a/src/pydrobert/torch/_parsing.py
+++ b/src/pydrobert/torch/_parsing.py
@@ -111,7 +111,7 @@ def parse_arpa_lm(file_: Union[TextIO, str], token2id: Optional[dict] = None) ->
         ngram_counts[n - 1] = count
     prob_dicts = [dict() for _ in ngram_counts]
     ngram_header_pattern = re.compile(r"^\\(\d+)-grams:$")
-    ngram_entry_pattern = re.compile(r"^(-?\d+(?:\.\d+)?)\s+(.*)$")
+    ngram_entry_pattern = re.compile(r"^(-?\d+(?:\.\d+)?(?:[Ee]-?\d+)?)\s+(.*)$")
     while line != "\\end\\":
         match = ngram_header_pattern.match(line)
         if match is None:

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -26,8 +26,8 @@ def test_parse_arpa_lm():
     file_ = SpooledTemporaryFile(mode="w+")
     file_.write(
         r"""\
-This is from https://cmusphinx.github.io/wiki/arpaformat/
-I've removed the backoff for </s> b/c IRSTLM likes to do things like that
+This is modified from https://cmusphinx.github.io/wiki/arpaformat/
+I've removed the backoff for </s> b/c IRSTLM likes to do things like that.
 
 \data\
 ngram 1=7
@@ -39,14 +39,14 @@ ngram 2=7
 -1.0000 </s>
 -0.6990 wood	 -0.2553
 -0.6990 cindy	-0.2553
--0.6990 pittsburgh		-0.2553
+-6.990e-01 pittsburgh		-0.2553
 -0.6990 jean	 -0.1973
 
 \2-grams:
 -0.2553 <unk> wood
 -0.2553 <s> <unk>
 -0.2553 wood pittsburgh
--0.2553 cindy jean
+-2.553E-1 cindy jean
 -0.2553 pittsburgh cindy
 -0.5563 jean </s>
 -0.5563 jean wood
@@ -76,6 +76,7 @@ ngram 2=7
         ("jean", "wood"),
     }
     assert abs(ngram_list[0]["cindy"][0] + 0.6990) < 1e-4
+    assert abs(ngram_list[0]["pittsburgh"][0] + 0.6990) < 1e-4
     assert abs(ngram_list[0]["jean"][1] + 0.1973) < 1e-4
     assert abs(ngram_list[1][("cindy", "jean")] + 0.2553) < 1e-4
     file_.seek(0)


### PR DESCRIPTION
KenLM can produce LMs with log probabilities in scientific notation. This PR allows us to parse them in parse_arpa.