### PR TITLE
Standardize argument checking for modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.4.0
 
+- Added `pydrobert.torch.argcheck` and standardized module argument checking a
+  bit
 - `parse_arpa` can handle log-probs in scientific notation (e.g. `1e4`)
 - Added `best_is_train` flag to `TrainingController.update_for_epoch`
 - Refactored `get-torch-spect-data-dir-info` to be faster

--- a/src/pydrobert/torch/_attn.py
+++ b/src/pydrobert/torch/_attn.py
@@ -565,9 +565,6 @@ class MultiHeadedAttention(GlobalSoftAttention):
         else:
             out_size = argcheck.is_nat(out_size, "out_size")
         num_heads = argcheck.is_nat(num_heads, "num_heads")
-        single_head_attention = argcheck.is_a(
-            single_head_attention, GlobalSoftAttention, "single_head_attention"
-        )
         if single_head_attention.dim < 0:
             raise ValueError(
                 "Negative dimensions are ambiguous for multi-headed attention"

--- a/src/pydrobert/torch/_attn.py
+++ b/src/pydrobert/torch/_attn.py
@@ -18,6 +18,7 @@ from typing import Optional
 
 import torch
 
+from . import argcheck
 from ._compat import broadcast_shapes, script, unflatten
 from ._wrappers import proxy
 
@@ -137,10 +138,11 @@ class GlobalSoftAttention(torch.nn.Module, metaclass=abc.ABCMeta):
     dim: int
 
     def __init__(self, query_size: int, key_size: int, dim: int = 0):
+        query_size = argcheck.is_nat(query_size, name="query_size")
+        key_size = argcheck.is_nat(key_size, name="key_size")
+        dim = argcheck.is_int(dim, name="dim")
         super().__init__()
-        self.query_size = query_size
-        self.key_size = key_size
-        self.dim = dim
+        self.query_size, self.key_size, self.dim = query_size, key_size, dim
 
     @abc.abstractmethod
     def score(self, query: torch.Tensor, key: torch.Tensor) -> torch.Tensor:
@@ -167,28 +169,27 @@ class GlobalSoftAttention(torch.nn.Module, metaclass=abc.ABCMeta):
             A tensor of scores of shape ``(E*, T, F*)``, where ``(E*)`` is the
             result of broadcasting ``(A*)`` with ``(B*, C*)``.
         """
-        raise NotImplementedError()
+        ...
 
-    @torch.jit.export
     def check_input(
         self,
         query: torch.Tensor,
         key: torch.Tensor,
         value: torch.Tensor,
         mask: Optional[torch.Tensor] = None,
-    ):
+    ) -> None:
         """Check if input is properly formatted, RuntimeError otherwise"""
         key_dim = key.dim()
         if query.dim() != key_dim - 1:
-            raise RuntimeError("query must have one fewer dimension than key")
+            raise ValueError("query must have one fewer dimension than key")
         if key_dim != value.dim():
-            raise RuntimeError("key must have same number of dimensions as value")
+            raise ValueError("key must have same number of dimensions as value")
         if query.shape[-1] != self.query_size:
-            raise RuntimeError("Last dimension of query must match query_size")
+            raise ValueError("Last dimension of query must match query_size")
         if key.shape[-1] != self.key_size:
-            raise RuntimeError("Last dimension of key must match key_size")
+            raise ValueError("Last dimension of key must match key_size")
         if self.dim > key_dim - 2 or key_dim == -1 or self.dim < -key_dim + 1:
-            raise RuntimeError(
+            raise ValueError(
                 f"dim must be in the range [{-key_dim + 1}, {key_dim - 2}] and not -1"
             )
         e_shape = broadcast_shapes(query.unsqueeze(self.dim).shape[:-1], key.shape[:-1])
@@ -268,6 +269,7 @@ class DotProductSoftAttention(GlobalSoftAttention):
     scale_factor: float
 
     def __init__(self, size: int, dim: int = 0, scale_factor: float = 1.0):
+        scale_factor = argcheck.is_float(scale_factor, name="scale_factor")
         super().__init__(size, size, dim)
         self.scale_factor = scale_factor
 
@@ -322,6 +324,7 @@ class GeneralizedDotProductSoftAttention(GlobalSoftAttention):
     def __init__(
         self, query_size: int, key_size: int, dim: int = 0, bias: bool = False
     ):
+        bias = argcheck.is_bool(bias, "bias")
         super().__init__(query_size, key_size, dim)
         self.weight = torch.nn.parameter.Parameter(torch.empty(query_size, key_size))
         if bias:
@@ -408,6 +411,8 @@ class ConcatSoftAttention(GlobalSoftAttention):
         bias: bool = False,
         hidden_size: int = 1000,
     ):
+        hidden_size = argcheck.is_nat(hidden_size, name="hidden_size")
+        bias = argcheck.is_bool(bias, name="bias")
         super().__init__(query_size, key_size, dim)
         self.weight = torch.nn.parameter.Parameter(
             torch.empty(hidden_size, query_size + key_size)
@@ -554,24 +559,40 @@ class MultiHeadedAttention(GlobalSoftAttention):
         bias_WV: bool = False,
         bias_WC: bool = False,
     ):
-        super().__init__(query_size, key_size, dim=single_head_attention.dim)
-        if self.dim < 0:
+        value_size = argcheck.is_nat(value_size, "value_size")
+        if out_size is None:
+            out_size = value_size
+        else:
+            out_size = argcheck.is_nat(out_size, "out_size")
+        num_heads = argcheck.is_nat(num_heads, "num_heads")
+        single_head_attention = argcheck.is_a(
+            single_head_attention, GlobalSoftAttention, "single_head_attention"
+        )
+        if single_head_attention.dim < 0:
             raise ValueError(
                 "Negative dimensions are ambiguous for multi-headed attention"
             )
-        self.value_size = value_size
-        self.out_size = value_size if out_size is None else out_size
-        self.num_heads = num_heads
+        if d_v is None:
+            d_v = max(1, value_size // num_heads)
+        else:
+            d_v = argcheck.is_nat(d_v, "d_v")
+        bias_WQ = argcheck.is_bool(bias_WQ, "bias_WQ")
+        bias_WK = argcheck.is_bool(bias_WQ, "bias_WK")
+        bias_WV = argcheck.is_bool(bias_WQ, "bias_WV")
+        bias_WC = argcheck.is_bool(bias_WC, "bias_WC")
+        super().__init__(query_size, key_size, dim=single_head_attention.dim)
+        self.value_size, self.out_size, self.num_heads = value_size, out_size, num_heads
+        self.single_head_attention = single_head_attention
         self.single_head_attention = single_head_attention
         # we don't keep these in sync in case someone's using
         # single_head_attention
         self.d_q = single_head_attention.query_size
         self.d_k = single_head_attention.key_size
-        self.d_v = max(1, value_size // num_heads) if d_v is None else d_v
+        self.d_v = d_v
         self.WQ = torch.nn.Linear(query_size, num_heads * self.d_q, bias=bias_WQ)
         self.WK = torch.nn.Linear(key_size, num_heads * self.d_k, bias=bias_WK)
-        self.WV = torch.nn.Linear(value_size, num_heads * self.d_v, bias=bias_WV)
-        self.WC = torch.nn.Linear(self.d_v * num_heads, self.out_size, bias=bias_WC)
+        self.WV = torch.nn.Linear(value_size, num_heads * d_v, bias=bias_WV)
+        self.WC = torch.nn.Linear(d_v * num_heads, out_size, bias=bias_WC)
         single_head_attention.reset_parameters()
 
     def check_input(
@@ -622,8 +643,9 @@ class MultiHeadedAttention(GlobalSoftAttention):
             # if the dimension is correct, a tensor of shape (1, ...) should always
             # broadcast
             mask_ = torch.ones((1,), device=query.device, dtype=torch.bool)
-            self.check_input(query, key, value, mask_)
-        else:
+            if not torch.jit.is_scripting():
+                self.check_input(query, key, value, mask_)
+        elif not torch.jit.is_scripting():
             self.check_input(query, key, value, mask)
         query_heads = self.WQ(query)
         query_heads = unflatten(query_heads, -1, [self.num_heads, self.d_q])

--- a/src/pydrobert/torch/_compat.py
+++ b/src/pydrobert/torch/_compat.py
@@ -189,8 +189,8 @@ else:
         script = torch.jit.script_if_tracing
     except AttributeError:
 
-        def script(obj, *args, **kwargs):
-            return obj
+        def script(func):
+            return func
 
 
 if _v < "1.10.0":

--- a/src/pydrobert/torch/_dataloaders.py
+++ b/src/pydrobert/torch/_dataloaders.py
@@ -40,7 +40,7 @@ import param
 import numpy as np
 import torch
 
-from . import config
+from . import config, argcheck
 from ._datasets import (
     ContextWindowDataParams,
     ContextWindowDataSet,
@@ -56,6 +56,9 @@ except TypeError:
     _BaseSampler = torch.utils.data.sampler.Sampler
 
 
+OnUnevenDistributed = Literal["raise", "drop", "uneven", "ignore"]
+
+
 class AbstractEpochSampler(_BaseSampler, metaclass=abc.ABCMeta):
     """ABC for sampling based on epoch"""
 
@@ -69,10 +72,15 @@ class AbstractEpochSampler(_BaseSampler, metaclass=abc.ABCMeta):
         self,
         data_source: Sized,
         init_epoch: int = 0,
-        on_uneven_distributed: Literal["raise", "drop", "uneven", "ignore"] = "raise",
+        on_uneven_distributed: OnUnevenDistributed = "raise",
     ):
         self.effective_total = self.total = len(data_source)
-        self.epoch = init_epoch
+        self.epoch = argcheck.is_int(init_epoch, name="init_epoch")
+        on_uneven_distributed = argcheck.is_in(
+            on_uneven_distributed,
+            {"raise", "drop", "uneven", "ignore"},
+            "on_uneven_distributed",
+        )
         if (
             on_uneven_distributed != "ignore"
             and torch.distributed.is_available()
@@ -90,12 +98,8 @@ class AbstractEpochSampler(_BaseSampler, metaclass=abc.ABCMeta):
                     )
                 elif on_uneven_distributed == "drop":
                     self.effective_total = self.total - (self.total % self._world_size)
-                elif on_uneven_distributed != "uneven":
-                    raise ValueError(
-                        "Unknown on_uneven_distributed value "
-                        f"'{on_uneven_distributed}'. Expected one of 'ignore', "
-                        "'raise', or 'drop'"
-                    )
+                else:
+                    assert on_uneven_distributed == "uneven"
         else:
             self._rank = 0
             self._world_size = 1
@@ -191,8 +195,9 @@ class EpochRandomSampler(AbstractEpochSampler):
             # torch so that we'll be deterministic with a prior call to
             # torch.manual_seed(...)
             base_seed = torch.randint(max_, (1,)).long().item()
-        if base_seed >= max_:
-            raise ValueError(f"base_seed is too high! Pick something less than {max_}")
+        else:
+            base_seed = argcheck.is_int(base_seed, "base_seed")
+            base_seed = argcheck.is_lte(base_seed, max_, "base_seed")
         self.base_seed = base_seed
 
     def get_samples_for_epoch_ignoring_distributed(self, epoch: int) -> Iterable[int]:
@@ -335,7 +340,7 @@ class BucketBatchSampler(_BaseSampler):
         self.sampler = sampler
         self.idx2bucket = idx2bucket
         self.bucket2size = bucket2size
-        self.drop_incomplete = drop_incomplete
+        self.drop_incomplete = argcheck.is_bool(drop_incomplete, "drop_incomplete")
 
     def __iter__(self) -> Iterator[List[int]]:
         batches: Dict[H, List[int]] = dict()
@@ -617,12 +622,13 @@ class LangDataLoader(torch.utils.data.DataLoader):
                 dl_kwargs[key] = val
         if data_params is None:
             data_params = params
-        self.batch_first, self.sort_batch = batch_first, sort_batch
+        batch_first = argcheck.is_bool(batch_first, "batch_first")
+        sort_batch = argcheck.is_bool(sort_batch, "sort_batch")
         if isinstance(data, LangDataSet):
             dataset = data
         else:
             dataset = LangDataSet(data, params=data_params, **ds_kwargs,)
-        utt_sampler_kwargs = {"init_epoch": init_epoch}
+        utt_sampler_kwargs = {"init_epoch": argcheck.is_int(init_epoch, "init_epoch")}
         if params.drop_last:
             utt_sampler_kwargs["on_uneven_distributed"] = "drop"
         else:
@@ -647,13 +653,13 @@ class LangDataLoader(torch.utils.data.DataLoader):
             batch_sampler = torch.utils.data.BatchSampler(
                 utt_sampler, params.batch_size, drop_last=params.drop_last
             )
-        self._len = None
         super().__init__(
             dataset,
             batch_sampler=batch_sampler,
             collate_fn=self.collate_fn,
             **dl_kwargs,
         )
+        self._len, self.batch_first, self.sort_batch = None, batch_first, sort_batch
 
     def collate_fn(self, seq):
         return lang_seq_to_batch(
@@ -1025,7 +1031,8 @@ class SpectDataLoader(torch.utils.data.DataLoader):
                     DeprecationWarning,
                 )
                 data_params.subset_ids = subset_ids
-        self.batch_first, self.sort_batch = batch_first, sort_batch
+        batch_first = argcheck.is_bool(batch_first, "batch_first")
+        sort_batch = argcheck.is_bool(sort_batch, "sort_batch")
         if isinstance(data, SpectDataSet):
             dataset = data
         else:
@@ -1063,13 +1070,13 @@ class SpectDataLoader(torch.utils.data.DataLoader):
             batch_sampler = torch.utils.data.BatchSampler(
                 utt_sampler, params.batch_size, drop_last=params.drop_last
             )
-        self._len = None
         super().__init__(
             dataset,
             batch_sampler=batch_sampler,
             collate_fn=self.collate_fn,
             **dl_kwargs,
         )
+        self._len, self.batch_first, self.sort_batch = None, batch_first, sort_batch
 
     def collate_fn(self, seq):
         return spect_seq_to_batch(

--- a/src/pydrobert/torch/_dataloaders.py
+++ b/src/pydrobert/torch/_dataloaders.py
@@ -34,7 +34,7 @@ from typing import (
     TypeVar,
     Union,
 )
-from typing_extensions import Literal
+from typing_extensions import Literal, get_args
 
 import param
 import numpy as np
@@ -78,7 +78,7 @@ class AbstractEpochSampler(_BaseSampler, metaclass=abc.ABCMeta):
         self.epoch = argcheck.is_int(init_epoch, name="init_epoch")
         on_uneven_distributed = argcheck.is_in(
             on_uneven_distributed,
-            {"raise", "drop", "uneven", "ignore"},
+            get_args(OnUnevenDistributed),
             "on_uneven_distributed",
         )
         if (

--- a/src/pydrobert/torch/_datasets.py
+++ b/src/pydrobert/torch/_datasets.py
@@ -410,21 +410,16 @@ class SpectDataSet(torch.utils.data.Dataset):
         file_prefix = argcheck.is_str(file_prefix, "file_prefix")
         file_suffix = argcheck.is_str(file_suffix, "file_suffix")
         warn_on_missing = argcheck.is_bool(warn_on_missing, "warn_on_missing")
-        if sos is not None:
-            sos = argcheck.is_int(sos, "sos")
-        if eos is not None:
-            sos = argcheck.is_int(eos, "eos")
+        sos = argcheck.is_int(sos, "sos", True)
+        eos = argcheck.is_int(eos, "eos", True)
         feat_subdir = argcheck.is_str(feat_subdir, "feat_subdir")
-        if ali_subdir is not None:
-            ali_subdir = argcheck.is_str(ali_subdir, "ali_subdir")
-        if ref_subdir is not None:
-            ref_subdir = argcheck.is_str(ref_subdir, "ref_subdir")
+        ali_subdir = argcheck.is_str(ali_subdir, "ali_subdir", True)
+        ref_subdir = argcheck.is_str(ref_subdir, "ref_subdir", True)
         if params is None:
             params = SpectDataParams()
         else:
             params = argcheck.is_a(params, SpectDataParams, "params")
-        if feat_mean is not None:
-            feat_mean = argcheck.is_tensor(feat_mean, "feat_mean")
+        feat_mean = argcheck.is_tensor(feat_mean, "feat_mean", True)
 
         if suppress_alis is None:
             warnings.warn(

--- a/src/pydrobert/torch/_datasets.py
+++ b/src/pydrobert/torch/_datasets.py
@@ -1144,7 +1144,7 @@ class ContextWindowDataSet(SpectDataSet):
         if params is None:
             params = ContextWindowDataParams()
         else:
-            params = argcheck.is_a(params, ContextWindowDataSet, "params")
+            params = argcheck.is_a(params, ContextWindowDataParams, "params")
         if left is not None:
             left = argcheck.is_nonnegi(left, "left")
             warnings.warn(

--- a/src/pydrobert/torch/_decoding.py
+++ b/src/pydrobert/torch/_decoding.py
@@ -1873,7 +1873,6 @@ class SequentialLanguageModelDistribution(
         cache_samples: bool = False,
         validate_args: Optional[bool] = None,
     ):
-        random_walk = argcheck.is_a(random_walk, RandomWalk, "random_walk")
         if batch_size is None:
             batch_shape = torch.Size([])
         else:

--- a/src/pydrobert/torch/_estimators.py
+++ b/src/pydrobert/torch/_estimators.py
@@ -19,6 +19,7 @@ from typing_extensions import TypeAlias
 
 import torch
 
+from . import argcheck
 
 FunctionOnSample: TypeAlias = Callable[[torch.Tensor], torch.Tensor]
 
@@ -93,6 +94,10 @@ class Estimator(metaclass=abc.ABCMeta):
         func: FunctionOnSample,
         is_log: bool = False,
     ):
+        proposal = argcheck.is_a(
+            proposal, torch.distributions.distribution.Distribution, "proposal"
+        )
+        is_log = argcheck.is_bool(is_log, "is_log")
         super().__init__()
         self.proposal = proposal
         self.func = func

--- a/src/pydrobert/torch/_estimators.py
+++ b/src/pydrobert/torch/_estimators.py
@@ -99,9 +99,7 @@ class Estimator(metaclass=abc.ABCMeta):
         )
         is_log = argcheck.is_bool(is_log, "is_log")
         super().__init__()
-        self.proposal = proposal
-        self.func = func
-        self.is_log = is_log
+        self.proposal, self.func, self.is_log = proposal, func, is_log
 
     @abc.abstractmethod
     def __call__(self) -> torch.Tensor:

--- a/src/pydrobert/torch/_feats.py
+++ b/src/pydrobert/torch/_feats.py
@@ -17,7 +17,7 @@ from typing_extensions import Literal
 
 import torch
 
-from . import config
+from . import config, argcheck
 from ._compat import script, movedim
 from ._wrappers import functional_wrapper, proxy
 
@@ -135,19 +135,21 @@ class MeanVarianceNormalization(torch.nn.Module):
         std: Optional[torch.Tensor] = None,
         eps: float = config.TINY,
     ):
+        dim = argcheck.is_int(dim, "dim")
         if mean is not None:
-            if mean.ndim != 1 or not mean.numel():
-                raise ValueError("mean must be a nonempty vector if specified")
+            mean = argcheck.is_tensor(mean, "mean")
+            mean = argcheck.has_ndim(mean, 1, "mean")
+            mean = argcheck.is_nonempty(mean, "mean")
         if std is not None:
-            if std.ndim != 1 or not std.numel():
-                raise ValueError("std must be a nonempty vector if specified")
+            std = argcheck.is_tensor(std, "std")
+            std = argcheck.has_ndim(std, 1, "std")
+            std = argcheck.is_nonempty(std, "std")
             if mean is not None and mean.size(0) != std.size(0):
                 raise ValueError(
                     "mean and std must be of the same length if both specified, got "
                     f"{mean.size(0)} and {std.size(0)}, respectively"
                 )
-        if eps < 0:
-            raise ValueError(f"eps must be non-negative, got {eps}")
+        eps = argcheck.is_nonneg(eps, "eps")
         super().__init__()
         self.dim, self.eps = dim, eps
         self.register_buffer("mean", mean)
@@ -371,11 +373,13 @@ class FeatureDeltas(torch.nn.Module):
         pad_mode: Literal["replicate", "constant", "reflect", "circular"] = "replicate",
         value: float = config.DEFT_PAD_VALUE,
     ):
-        if pad_mode not in {"replicate", "constant", "reflect", "circular"}:
-            raise ValueError(
-                "Expected pad_mode to be one of 'replicate', 'constant', 'reflect', or "
-                f"'circular', got '{pad_mode}'"
-            )
+        dim = argcheck.is_int(dim, "dim")
+        time_dim = argcheck.is_int(time_dim, "time_dim")
+        concatenate = argcheck.is_bool(concatenate, "concatenate")
+        order = argcheck.is_nonnegi(order, "order")
+        pad_mode = argcheck.is_in(
+            pad_mode, {"replicate", "constant", "reflect", "circular"}, pad_mode
+        )
         super().__init__()
         self.register_buffer("filters", _feat_delta_filters(order, width))
         self.dim, self.time_dim, self.value = dim, time_dim, value
@@ -430,7 +434,9 @@ def slice_spect_data(
     lobe_size: int = 0,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     if input.ndim < 2:
-        raise RuntimeError(f"Expected input to be at least 2-dimensional; got {input.ndim}")
+        raise RuntimeError(
+            f"Expected input to be at least 2-dimensional; got {input.ndim}"
+        )
     N, T = input.shape[:2]
     device = input.device
     if not T:
@@ -729,7 +735,7 @@ class SliceSpectData(torch.nn.Module):
         [[0, 2], [2, 5], [3, 7]]  # future, not valid_only
     """
 
-    __constants__ = ["policy", "window_type", "valid_only", "lobe_size"]
+    __constants__ = "policy", "window_type", "valid_only", "lobe_size"
 
     policy: str
     window_type: str
@@ -743,18 +749,13 @@ class SliceSpectData(torch.nn.Module):
         valid_only: bool = True,
         lobe_size: int = 0,
     ) -> None:
+        policy = argcheck.is_in(policy, ["fixed", "ali", "ref"], "policy")
+        window_type = argcheck.is_in(
+            window_type, ["symmnetric", "causal", "future"], "window_type"
+        )
+        valid_only = argcheck.is_bool(valid_only, "valid_only")
+        lobe_size = argcheck.is_nonnegi(lobe_size, "lobe_size")
         super().__init__()
-        if policy not in {"fixed", "ali", "ref"}:
-            raise ValueError(
-                f"policy should be one of 'fixed', 'ali', or 'ref'. Got '{policy}'"
-            )
-        if window_type not in {"symmetric", "causal", "future"}:
-            raise ValueError(
-                "window_type should be one of 'symmetric', 'causal', or 'future'. "
-                f"Got '{window_type}'"
-            )
-        if lobe_size < 0:
-            raise ValueError(f"lobe_size should be non-negative, got {lobe_size}")
         self.policy, self.window_type, self.lobe_size = policy, window_type, lobe_size
         self.valid_only = valid_only
 
@@ -816,10 +817,14 @@ def chunk_token_sequences_by_slices(
     mask = mask & (refs[..., 1:] >= 0).all(2) & (refs[..., 2] >= refs[..., 1])
     if partial:
         # slice_start < ref_end and slice_end > ref_start
-        mask = mask & (slices[..., :1] < refs[..., 2]) & (slices[..., 1:] > refs[..., 1])
+        mask = (
+            mask & (slices[..., :1] < refs[..., 2]) & (slices[..., 1:] > refs[..., 1])
+        )
     else:
         # slice_start <= ref_start and slice_end >= ref_end
-        mask = mask & (slices[..., :1] <= refs[..., 1]) & (slices[..., 1:] >= refs[..., 2])
+        mask = (
+            mask & (slices[..., :1] <= refs[..., 1]) & (slices[..., 1:] >= refs[..., 2])
+        )
     chunked_lens = mask.long().sum(1)
     refs = refs[mask.unsqueeze(2).expand_as(refs)]
     mask = (chunked_lens.unsqueeze(1) > arange).unsqueeze(2).expand(N, R, 3)
@@ -894,9 +899,10 @@ class ChunkTokenSequencesBySlices(torch.nn.Module):
     retain: bool
 
     def __init__(self, partial: bool = False, retain: bool = False) -> None:
+        partial = argcheck.is_bool(partial, "partial")
+        retain = argcheck.is_bool(retain, "retain")
         super().__init__()
-        self.partial = partial
-        self.retain = retain
+        self.partial, self.retain = partial, retain
 
     def extra_repr(self) -> str:
         if self.partial and self.retain:

--- a/src/pydrobert/torch/_img.py
+++ b/src/pydrobert/torch/_img.py
@@ -28,6 +28,7 @@ from typing_extensions import Literal
 
 import torch
 
+from . import argcheck
 from ._pad import pad_variable
 from ._compat import meshgrid, script, linalg_solve
 from ._wrappers import functional_wrapper, proxy
@@ -198,7 +199,7 @@ class PolyharmonicSpline(torch.nn.Module):
         points (linearly independent). See the Wikipedia entry on splnes for more info.
     """
 
-    __constants__ = ["order", "regularization_weight", "full_matrix"]
+    __constants__ = "order", "regularization_weight", "full_matrix"
 
     order: int
     regularization_weight: float
@@ -207,9 +208,12 @@ class PolyharmonicSpline(torch.nn.Module):
     def __init__(
         self, order: int, regularization_weight: float = 0.0, full_matrix: bool = True
     ):
+        order = argcheck.is_posi(order, "order")
+        regularization_weight = argcheck.is_float(
+            regularization_weight, "regularization_weight"
+        )
+        full_matrix = argcheck.is_bool(full_matrix, "full_matrix")
         super().__init__()
-        if order <= 0:
-            raise ValueError(f"order must be positive, got {order}")
         self.order = order
         self.regularization_weight = regularization_weight
         self.full_matrix = full_matrix
@@ -347,9 +351,12 @@ class Warp1DGrid(torch.nn.Module):
     max_length: Optional[int]
 
     def __init__(self, max_length: Optional[int] = None, interpolation_order: int = 1):
+        if max_length is not None:
+            max_length = argcheck.is_nonnegi(max_length, "max_length")
+        interpolation_order = argcheck.is_posi(
+            interpolation_order, "interpolation_order"
+        )
         super().__init__()
-        if max_length is not None and max_length < 0:
-            raise ValueError("max_length must be non-negative")
         self.max_length = max_length
         self.interpolation_order = interpolation_order
 
@@ -487,21 +494,13 @@ class DenseImageWarp(torch.nn.Module):
         mode: Literal["bilinear", "nearest"] = "bilinear",
         padding_mode: Literal["border", "zeros", "reflection"] = "border",
     ):
+        indexing = argcheck.is_in(indexing, ["hw", "wh"], "indexing")
+        mode = argcheck.is_in(mode, ["bilinear", "nearest"], "mode")
+        padding_mode = argcheck.is_in(
+            padding_mode, ["border", "zeros", "reflection"], "padding_mode"
+        )
         super().__init__()
-        if indexing not in {"hw", "wh"}:
-            raise ValueError(f"indexing must be either 'hw' or 'wh', got '{indexing}'")
-        if mode not in {"bilinear", "nearest"}:
-            raise ValueError(
-                f"mode must be either 'bilinear' or 'nearest', got '{mode}'"
-            )
-        if padding_mode not in {"border", "zeros", "reflection"}:
-            raise ValueError(
-                "padding_mode must be one of 'border', 'zeros', or 'relection', got "
-                f"'{padding_mode}'"
-            )
-        self.indexing = indexing
-        self.mode = mode
-        self.padding_mode = padding_mode
+        self.indexing, self.mode, self.padding_mode = indexing, mode, padding_mode
 
     def forward(self, image: torch.Tensor, flow: torch.Tensor) -> torch.Tensor:
         return dense_image_warp(
@@ -811,29 +810,27 @@ class SparseImageWarp(torch.nn.Module):
         dense_padding_mode: Literal["border", "zero", "reflection"] = "border",
         include_flow: bool = True,
     ):
+        indexing = argcheck.is_in(indexing, ["hw", "wh"], "indexing")
+        field_interpolation_order = argcheck.is_posi(
+            field_interpolation_order, "field_interpolation_order"
+        )
+        field_regularization_weight = argcheck.is_float(
+            field_regularization_weight, "field_regularization_weight"
+        )
+        field_full_matrix = argcheck.is_bool(field_full_matrix, "field_ful_matrix")
+        pinned_boundary_points = argcheck.is_nonnegi(
+            pinned_boundary_points, "pinned_boundary_points"
+        )
+        dense_interpolation_mode = argcheck.is_in(
+            dense_interpolation_mode,
+            ["bilinear", "nearest"],
+            "dense_interpolation_mode",
+        )
+        dense_padding_mode = argcheck.is_in(
+            dense_padding_mode, ["border", "zero", "reflection"], dense_padding_mode
+        )
+        include_flow = argcheck.is_bool(include_flow, "include_flow")
         super().__init__()
-        if field_interpolation_order <= 0:
-            raise ValueError(
-                "field_interpolation_order must be positive, got "
-                f"{field_interpolation_order}"
-            )
-        if pinned_boundary_points < 0:
-            raise ValueError(
-                "pinned_boundary_points must be non-negative, got "
-                f"{pinned_boundary_points}"
-            )
-        if indexing not in {"hw", "wh"}:
-            raise ValueError(f"indexing must be either 'hw' or 'wh', got '{indexing}'")
-        if dense_interpolation_mode not in {"bilinear", "nearest"}:
-            raise ValueError(
-                "dense_interpolation_mode must be either 'bilinear' or 'nearest', got "
-                f"'{dense_interpolation_mode}'"
-            )
-        if dense_padding_mode not in {"border", "zeros", "reflection"}:
-            raise ValueError(
-                "dense_padding_mode must be one of 'border', 'zeros', or 'relection', "
-                f"got '{dense_padding_mode}'"
-            )
         self.indexing = indexing
         self.field_interpolation_order = field_interpolation_order
         self.field_regularization_weight = field_regularization_weight
@@ -980,9 +977,8 @@ class RandomShift(torch.nn.Module):
         mode: Literal["reflect", "constant", "replicate"] = "reflect",
         value: float = 0.0,
     ):
-        super().__init__()
         try:
-            prop = (float(prop), float(prop))
+            prop = (argcheck.is_float(prop, "prop"), float(prop))
         except TypeError:
             prop = tuple(prop)
         if len(prop) != 2:
@@ -991,19 +987,15 @@ class RandomShift(torch.nn.Module):
             )
         if prop[0] < 0.0 or prop[1] < 0.0:
             raise ValueError("prop values must be non-negative")
+        mode = argcheck.is_in(mode, ["reflect", "constant", "replicate"], "mode")
         if mode == "reflect":
             if prop[0] > 1.0 or prop[1] > 1.0:
                 raise NotImplementedError(
                     "if 'mode' is 'reflect', values in 'prop' must be <= 1"
                 )
-        elif mode not in {"constant", "replicate"}:
-            raise ValueError(
-                "'mode' must be one of 'reflect', 'constant', or 'replicate', got "
-                f"'{mode}'"
-            )
-        self.mode = mode
-        self.prop = prop
-        self.value = value
+        value = argcheck.is_float(value, "value")
+        super().__init__()
+        self.mode, self.prop, self.value = mode, prop, value
 
     def extra_repr(self) -> str:
         return f"prop={self.prop}, mode={self.mode}, value={self.value}"
@@ -1359,7 +1351,7 @@ class SpecAugment(torch.nn.Module):
     of frequency that occurred due to the 2D warp was unintentional.
     """
 
-    __constants__ = [
+    __constants__ = (
         "max_time_warp",
         "max_freq_warp",
         "max_time_mask",
@@ -1369,7 +1361,7 @@ class SpecAugment(torch.nn.Module):
         "num_time_mask_proportion",
         "num_freq_mask",
         "interpolation_order",
-    ]
+    )
 
     max_time_warp: float
     max_freq_warp: float
@@ -1393,9 +1385,24 @@ class SpecAugment(torch.nn.Module):
         num_freq_mask: int = 2,
         interpolation_order: int = 1,
     ):
+        max_time_warp = argcheck.is_nonnegf(max_time_warp, "max_time_warp")
+        max_freq_warp = argcheck.is_nonnegf(max_freq_warp, "max_freq_warp")
+        max_time_mask = argcheck.is_nonnegi(max_time_mask, "max_time_mask")
+        max_freq_mask = argcheck.is_nonnegi(max_freq_mask, "max_freq_mask")
+        max_time_mask_proportion = argcheck.is_closed01(
+            max_time_mask_proportion, "max_time_mask_proportion"
+        )
+        num_time_mask = argcheck.is_nonnegi(num_time_mask, "num_time_mask")
+        num_time_mask_proportion = argcheck.is_closed01(
+            num_time_mask_proportion, "num_time_mask_proportion"
+        )
+        num_freq_mask = argcheck.is_nonnegi(num_freq_mask, "num_freq_mask")
+        interpolation_order = argcheck.is_posi(
+            interpolation_order, "interpolation_order"
+        )
         super().__init__()
-        self.max_time_warp = float(max_time_warp)
-        self.max_freq_warp = float(max_freq_warp)
+        self.max_time_warp = max_time_warp
+        self.max_freq_warp = max_freq_warp
         self.max_time_mask = max_time_mask
         self.max_freq_mask = max_freq_mask
         self.max_time_mask_proportion = max_time_mask_proportion

--- a/src/pydrobert/torch/_mc.py
+++ b/src/pydrobert/torch/_mc.py
@@ -138,8 +138,7 @@ class DirectEstimator(MonteCarloEstimator):
         cv_mean: Optional[torch.Tensor] = None,
         is_log: bool = False,
     ):
-        if cv_mean is not None:
-            cv_mean = argcheck.is_tensor(cv_mean, "cv_mean")
+        cv_mean = argcheck.is_tensor(cv_mean, "cv_mean", True)
         super().__init__(proposal, func, mc_samples, is_log)
         self.cv, self.cv_mean = cv, cv_mean
 

--- a/src/pydrobert/torch/_mc.py
+++ b/src/pydrobert/torch/_mc.py
@@ -18,7 +18,7 @@ from typing import Optional, Sequence, Tuple
 
 import torch
 
-from . import config
+from . import config, argcheck
 from .distributions import Density, StraightThrough, ConditionalStraightThrough
 from ._estimators import Estimator, FunctionOnSample
 from ._compat import logaddexp
@@ -72,8 +72,9 @@ class MonteCarloEstimator(Estimator, metaclass=abc.ABCMeta):
         mc_samples: int,
         is_log: bool = False,
     ) -> None:
-        if mc_samples <= 0:
-            raise ValueError(f"mc_samples must be a natural number, got {mc_samples}")
+        proposal = argcheck.is_a(proposal, torch.distributions.Distribution, "proposal")
+        mc_samples = argcheck.is_posi(mc_samples, "mc_samples")
+        is_log = argcheck.is_bool(is_log, "is_log")
         super().__init__(proposal, func, is_log)
         self.mc_samples = mc_samples
 
@@ -137,9 +138,10 @@ class DirectEstimator(MonteCarloEstimator):
         cv_mean: Optional[torch.Tensor] = None,
         is_log: bool = False,
     ):
+        if cv_mean is not None:
+            cv_mean = argcheck.is_tensor(cv_mean, "cv_mean")
         super().__init__(proposal, func, mc_samples, is_log)
-        self.cv = cv
-        self.cv_mean = cv_mean
+        self.cv, self.cv_mean = cv, cv_mean
 
     def __call__(self) -> torch.Tensor:
         b = self.proposal.sample([self.mc_samples])
@@ -290,8 +292,7 @@ class StraightThroughEstimator(MonteCarloEstimator):
         mc_samples: int,
         is_log: bool = False,
     ) -> None:
-        if not isinstance(proposal, StraightThrough):
-            raise ValueError("proposal must be StraightThrough")
+        proposal = argcheck.is_a(proposal, StraightThrough, "proposal")
         super().__init__(proposal, func, mc_samples, is_log)
 
     def __call__(self) -> torch.Tensor:
@@ -382,6 +383,7 @@ class ImportanceSamplingEstimator(MonteCarloEstimator):
         self_normalize: bool = False,
         is_log: bool = False,
     ) -> None:
+        self_normalize = argcheck.is_bool(self_normalize, "self_normalize")
         super().__init__(proposal, func, mc_samples, is_log)
         self.density = density
         self.self_normalize = self_normalize
@@ -501,8 +503,7 @@ class RelaxEstimator(MonteCarloEstimator):
         cv_params: Sequence[torch.Tensor] = tuple(),
         is_log: bool = False,
     ) -> None:
-        if not isinstance(proposal, ConditionalStraightThrough):
-            raise ValueError(f"proposal must implement ConditionalStraightThrough")
+        proposal = argcheck.is_a(proposal, ConditionalStraightThrough, "proposal")
         proposal_params = tuple(proposal_params)
         cv_params = tuple(cv_params)
         if (len(proposal_params) > 0) != (len(cv_params) > 0):
@@ -510,9 +511,7 @@ class RelaxEstimator(MonteCarloEstimator):
                 "either both proposal_params and cv_params must be specified or neither"
             )
         super().__init__(proposal, func, mc_samples, is_log)
-        self.cv = cv
-        self.proposal_params = proposal_params
-        self.cv_params = cv_params
+        self.cv, self.proposal_params, self.cv_params = cv, proposal_params, cv_params
 
     def __call__(self) -> torch.Tensor:
         z = self.proposal.rsample([self.mc_samples])
@@ -650,9 +649,9 @@ class IndependentMetropolisHastingsEstimator(MonteCarloEstimator):
         initial_sample_tries: int = 1000,
         is_log: bool = False,
     ) -> None:
-        super().__init__(proposal, func, mc_samples, is_log)
-        if burn_in < 0 or burn_in >= mc_samples:
-            raise ValueError(f"burn_in must be between [0, mc_samples={mc_samples})")
+        burn_in = argcheck.is_nonnegi(burn_in, "burn_in")
+        mc_samples = argcheck.is_posi(mc_samples, "mc_samples")
+        argcheck.is_lt(burn_in, mc_samples, "burn_in", "mc_samples")
         if initial_sample is not None:
             sample_shape = self.proposal.batch_shape + self.proposal.event_shape
             if initial_sample.shape == sample_shape:
@@ -670,10 +669,9 @@ class IndependentMetropolisHastingsEstimator(MonteCarloEstimator):
             raise ValueError(
                 "initial_sample_tries must be positive when initial_sample is None"
             )
-        self.density = density
-        self.initial_sample = initial_sample
-        self.initial_sample_tries = initial_sample_tries
-        self.burn_in = burn_in
+        super().__init__(proposal, func, mc_samples, is_log)
+        self.density, self.initial_sample = density, initial_sample
+        self.initial_sample_tries, self.burn_in = initial_sample_tries, burn_in
 
     def find_initial_sample(self, tries: Optional[int] = None) -> torch.Tensor:
         """Find an initial sample by randomly sampling from the proposal"""
@@ -753,14 +751,14 @@ def _attach_grad(x: torch.tensor, g: torch.Tensor):
 
 class _RebarControlVariate(torch.nn.Module):
 
-    __constants__ = ["func", "start_temp", "start_eta"]
+    __constants__ = ("func", "start_temp", "start_eta")
     func: FunctionOnSample
     start_temp: float
     start_eta: float
 
     def __init__(self, func, start_temp: float = 0.1, start_eta: float = 1.0) -> None:
-        if start_temp <= 0:
-            raise ValueError(f"start_temp must be positive, got {start_temp}")
+        start_temp = argcheck.is_posf(start_temp, "start_temp")
+        start_eta = argcheck.is_float(start_eta, "start_eta")
         super().__init__()
         self.func = func
         self.start_temp = start_temp

--- a/src/pydrobert/torch/_pl_data.py
+++ b/src/pydrobert/torch/_pl_data.py
@@ -288,7 +288,8 @@ class LitDataModule(pl.LightningDataModule, Generic[P, DS, DL], metaclass=abc.AB
         pin_memory: Optional[bool] = None,
     ) -> None:
         params = argcheck.is_a(params, self.pclass, "params")
-        num_workers = argcheck.is_nonnegi(num_workers, "num_workers", True)
+        if num_workers is not None:
+            num_workers = argcheck.is_nonnegi(num_workers, "num_workers")
         pin_memory = argcheck.is_bool(pin_memory, "pin_memory", True)
         super().__init__()
 

--- a/src/pydrobert/torch/_pl_data.py
+++ b/src/pydrobert/torch/_pl_data.py
@@ -18,7 +18,7 @@ import abc
 
 from pathlib import PurePath
 from typing import Dict, Optional, TypeVar, Generic, Type, Union
-from typing_extensions import Literal
+from typing_extensions import Literal, get_args
 
 import torch
 import param
@@ -26,6 +26,7 @@ import pytorch_lightning as pl
 import pydrobert.param.abc as pabc
 import pydrobert.param.argparse as pargparse
 
+from . import argcheck
 from ._datasets import SpectDataSet
 from ._dataloaders import (
     SpectDataLoader,
@@ -35,6 +36,9 @@ from ._dataloaders import (
 
 
 StrPath = Union[str, os.PathLike]
+FileType = Literal["dir", "file"]
+OnUnevenDistributed = Literal["raise", "uneven", "ignore"]
+P = TypeVar("P", bound=param.Parameterized)
 
 
 class PosixPath(param.Parameter):
@@ -48,25 +52,26 @@ class PosixPath(param.Parameter):
         If :obj:`True`, setting to 
     """
 
-    __slots__ = ["always_exists", "type"]
+    __slots__ = "always_exists", "type"
 
     always_exists: bool
-    type: Optional[Literal["dir", "file"]]
+    type: Optional[FileType]
 
     def __init__(
         self,
         default: Optional[StrPath] = None,
         always_exists: bool = True,
-        type: Optional[Literal["dir", "file"]] = None,
+        type: Optional[FileType] = None,
         **params,
     ):
-        if type not in {"dir", "file", None}:
-            raise ValueError(
-                f"type must be one of 'dir', 'file', or None; got '{type}'"
-            )
+        if default is not None:
+            default = argcheck.is_str(default, "default")
+        if type is not None:
+            type = argcheck.is_in(type, get_args(FileType), "type")
+        always_exists = argcheck.is_bool(always_exists, "always_exists")
+        super().__init__(default=default, **params)
         self.always_exists = always_exists
         self.type = type
-        super().__init__(default=default, **params)
 
     def __get__(self, obj, objtype) -> Optional[str]:
         path: Optional[StrPath] = super().__get__(obj, objtype)
@@ -106,9 +111,6 @@ class LitDataModuleParamsMetaclass(pabc.AbstractParameterizedMetaclass):
         mcs.param.params()["val"].class_ = pclass
         mcs.param.params()["test"].class_ = pclass
         mcs.param.params()["predict"].class_ = pclass
-
-
-P = TypeVar("P", bound=param.Parameterized)
 
 
 class LitDataModuleParams(
@@ -264,6 +266,8 @@ class LitDataModuleParams(
 DS = TypeVar("DS", bound=torch.utils.data.Dataset)
 DL = TypeVar("DL", bound=torch.utils.data.DataLoader)
 
+Partition = Literal["train", "val", "test", "predict"]
+
 
 class LitDataModule(pl.LightningDataModule, Generic[P, DS, DL], metaclass=abc.ABCMeta):
     """An ABC handling DataLoader parameterizations and partitions for lightning"""
@@ -323,19 +327,11 @@ class LitDataModule(pl.LightningDataModule, Generic[P, DS, DL], metaclass=abc.AB
         return self._pin_memory
 
     @abc.abstractmethod
-    def construct_dataset(
-        self,
-        partition: Literal["train", "val", "test", "predict"],
-        path: str,
-        params: P,
-    ) -> DS:
+    def construct_dataset(self, partition: Partition, path: str, params: P,) -> DS:
         ...
 
     def _construct_dataset_with_checks(
-        self,
-        partition: Literal["train", "val", "test", "predict"],
-        path: Optional[str],
-        params: Optional[P],
+        self, partition: Partition, path: Optional[str], params: Optional[P],
     ) -> DS:
         if path is None:
             raise ValueError(f"Cannot construct {partition} dataset: no data directory")
@@ -391,16 +387,11 @@ class LitDataModule(pl.LightningDataModule, Generic[P, DS, DL], metaclass=abc.AB
             )
 
     @abc.abstractmethod
-    def construct_dataloader(
-        self, partition: Literal["train", "val", "test", "predict"], ds: DS, params: P
-    ) -> DL:
+    def construct_dataloader(self, partition: Partition, ds: DS, params: P) -> DL:
         ...
 
     def _construct_dataloader_with_checks(
-        self,
-        partition: Literal["train", "val", "test", "predict"],
-        ds: Optional[DS],
-        params: Optional[P],
+        self, partition: Partition, ds: Optional[DS], params: Optional[P],
     ) -> DL:
         if params is None:
             raise ValueError(
@@ -574,12 +565,12 @@ class LitSpectDataModule(
     suppress_uttids: Optional[bool]
     shuffle: Optional[bool]
     warn_on_missing: bool
-    on_uneven_distributed: Literal["raise", "uneven", "ignore"]
+    on_uneven_distributed: OnUnevenDistributed
 
     _num_filts: Optional[int]
     _info_dict: Optional[Dict[str, int]]
-    _mvn_mean = Optional[torch.Tensor]
-    _mvn_std = Optional[torch.Tensor]
+    _mvn_mean: Optional[torch.Tensor]
+    _mvn_std: Optional[torch.Tensor]
 
     def __init__(
         self,
@@ -593,8 +584,29 @@ class LitSpectDataModule(
         num_workers: Optional[int] = None,
         pin_memory: Optional[bool] = None,
         warn_on_missing: bool = True,
-        on_uneven_distributed: Literal["raise", "uneven", "ignore"] = "raise",
+        on_uneven_distributed: OnUnevenDistributed = "raise",
     ) -> None:
+        data_params = argcheck.is_a(
+            data_params, LitSpectDataModuleParams, "data_params"
+        )
+        batch_first = argcheck.is_bool(batch_first, "batch_first")
+        sort_batch = argcheck.is_bool(sort_batch, "sort_batch")
+        suppress_alis = argcheck.is_bool(suppress_alis, "suppress_alis")
+        tokens_only = argcheck.is_bool(tokens_only, "tokens_only")
+        if suppress_uttids is not None:
+            suppress_uttids = argcheck.is_bool(suppress_uttids, "suppress_uttids")
+        if shuffle is not None:
+            shuffle = argcheck.is_bool(shuffle, "shuffle")
+        if num_workers is not None:
+            num_workers = argcheck.is_nonnegi(num_workers, "num_workers")
+        if pin_memory is not None:
+            pin_memory = argcheck.is_bool(pin_memory, "pin_memory")
+        warn_on_missing = argcheck.is_bool(warn_on_missing, "warn_on_missing")
+        on_uneven_distributed = argcheck.is_in(
+            on_uneven_distributed,
+            get_args(OnUnevenDistributed),
+            "on_uneven_distributed",
+        )
         super().__init__(data_params, num_workers, pin_memory)
 
         self.batch_first = batch_first
@@ -605,7 +617,7 @@ class LitSpectDataModule(
         self.shuffle = shuffle
         self.warn_on_missing = warn_on_missing
         self.on_uneven_distributed = on_uneven_distributed
-        self._info_dict = None
+        self._info_dict = self._mvn_mean = self._mvn_std = None
 
     def get_info_dict_value(
         self, key: str, default: Optional[int] = None
@@ -670,10 +682,7 @@ class LitSpectDataModule(
         return None if self._info_dict is None else self._info_dict["num_filts"]
 
     def construct_dataset(
-        self,
-        partition: Literal["train", "val", "test", "predict"],
-        path: str,
-        params: SpectDataLoaderParams,
+        self, partition: Partition, path: str, params: SpectDataLoaderParams,
     ) -> SpectDataSet:
         suppress_uttids = self.suppress_uttids
         if suppress_uttids is None:
@@ -709,16 +718,14 @@ class LitSpectDataModule(
             and self._mvn_std is None
         ):
             dict_ = torch.load(self.params.mvn_path, "cpu")
+
             self._mvn_mean = dict_["mean"]
             self._mvn_std = dict_["std"]
 
         super().setup(stage)
 
     def construct_dataloader(
-        self,
-        partition: Literal["train", "val", "test", "predict"],
-        ds: SpectDataSet,
-        params: SpectDataLoaderParams,
+        self, partition: Partition, ds: SpectDataSet, params: SpectDataLoaderParams,
     ) -> SpectDataLoader:
         shuffle = self.shuffle
         if shuffle is None:

--- a/src/pydrobert/torch/_pl_data.py
+++ b/src/pydrobert/torch/_pl_data.py
@@ -64,10 +64,8 @@ class PosixPath(param.Parameter):
         type: Optional[FileType] = None,
         **params,
     ):
-        if default is not None:
-            default = argcheck.is_str(default, "default")
-        if type is not None:
-            type = argcheck.is_in(type, get_args(FileType), "type")
+        default = argcheck.is_str(default, "default", True)
+        type = argcheck.is_in(type, get_args(FileType), "type", True)
         always_exists = argcheck.is_bool(always_exists, "always_exists")
         super().__init__(default=default, **params)
         self.always_exists = always_exists
@@ -290,10 +288,8 @@ class LitDataModule(pl.LightningDataModule, Generic[P, DS, DL], metaclass=abc.AB
         pin_memory: Optional[bool] = None,
     ) -> None:
         params = argcheck.is_a(params, self.pclass, "params")
-        if num_workers is not None:
-            num_workers = argcheck.is_nonnegi(num_workers, "num_workers")
-        if pin_memory is not None:
-            pin_memory = argcheck.is_bool(pin_memory, "pin_memory")
+        num_workers = argcheck.is_nonnegi(num_workers, "num_workers", True)
+        pin_memory = argcheck.is_bool(pin_memory, "pin_memory", True)
         super().__init__()
 
         self.params = params
@@ -596,10 +592,8 @@ class LitSpectDataModule(
         sort_batch = argcheck.is_bool(sort_batch, "sort_batch")
         suppress_alis = argcheck.is_bool(suppress_alis, "suppress_alis")
         tokens_only = argcheck.is_bool(tokens_only, "tokens_only")
-        if suppress_uttids is not None:
-            suppress_uttids = argcheck.is_bool(suppress_uttids, "suppress_uttids")
-        if shuffle is not None:
-            shuffle = argcheck.is_bool(shuffle, "shuffle")
+        suppress_uttids = argcheck.is_bool(suppress_uttids, "suppress_uttids", True)
+        shuffle = argcheck.is_bool(shuffle, "shuffle", True)
         warn_on_missing = argcheck.is_bool(warn_on_missing, "warn_on_missing")
         on_uneven_distributed = argcheck.is_in(
             on_uneven_distributed,

--- a/src/pydrobert/torch/_pl_data.py
+++ b/src/pydrobert/torch/_pl_data.py
@@ -289,8 +289,11 @@ class LitDataModule(pl.LightningDataModule, Generic[P, DS, DL], metaclass=abc.AB
         num_workers: Optional[int] = None,
         pin_memory: Optional[bool] = None,
     ) -> None:
-        if not isinstance(params, self.pclass):
-            raise ValueError(f"Incorrect parameter class {type(params)}")
+        params = argcheck.is_a(params, self.pclass, "params")
+        if num_workers is not None:
+            num_workers = argcheck.is_nonnegi(num_workers, "num_workers")
+        if pin_memory is not None:
+            pin_memory = argcheck.is_bool(pin_memory, "pin_memory")
         super().__init__()
 
         self.params = params
@@ -597,10 +600,6 @@ class LitSpectDataModule(
             suppress_uttids = argcheck.is_bool(suppress_uttids, "suppress_uttids")
         if shuffle is not None:
             shuffle = argcheck.is_bool(shuffle, "shuffle")
-        if num_workers is not None:
-            num_workers = argcheck.is_nonnegi(num_workers, "num_workers")
-        if pin_memory is not None:
-            pin_memory = argcheck.is_bool(pin_memory, "pin_memory")
         warn_on_missing = argcheck.is_bool(warn_on_missing, "warn_on_missing")
         on_uneven_distributed = argcheck.is_in(
             on_uneven_distributed,

--- a/src/pydrobert/torch/_rl.py
+++ b/src/pydrobert/torch/_rl.py
@@ -14,6 +14,7 @@
 
 import torch
 
+from . import argcheck
 from ._compat import script
 from ._wrappers import functional_wrapper, proxy
 
@@ -75,15 +76,16 @@ class TimeDistributedReturn(torch.nn.Module):
         A tensor of shape ``(T, N)`` of the time-distributed rewards.
     """
 
-    __constants__ = ["gamma", "batch_first"]
+    __constants__ = "gamma", "batch_first"
 
     gamma: float
     batch_first: bool
 
     def __init__(self, gamma: float, batch_first: bool):
+        gamma = argcheck.is_float(gamma, "gamma")
+        batch_first = argcheck.is_bool(batch_first, "batch_first")
         super().__init__()
-        self.gamma = gamma
-        self.batch_first = batch_first
+        self.gamma, self.batch_first = gamma, batch_first
 
     def extra_repr(self) -> str:
         return f"gamma={self.gamma},batch_first={self.batch_first}"

--- a/src/pydrobert/torch/_straight_through.py
+++ b/src/pydrobert/torch/_straight_through.py
@@ -39,6 +39,7 @@ from torch.distributions.utils import (
     probs_to_logits,
 )
 
+from . import argcheck
 from ._compat import check_methods, euler_constant, one_hot
 
 
@@ -239,11 +240,11 @@ class Density(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def log_prob(self, value: torch.Tensor) -> torch.Tensor:
         ...
-    
+
     @classmethod
     def __subclasshook__(cls, C) -> bool:
         if cls is Density:
-            return check_methods(C, 'log_prob')
+            return check_methods(C, "log_prob")
         return NotImplemented
 
 
@@ -297,12 +298,12 @@ class LogisticBernoulli(ConditionalStraightThrough):
         logits: Optional[torch.Tensor] = None,
         validate_args: Optional[bool] = None,
     ):
-        if (probs is None) == (logits is None):
+        if (probs is None) is (logits is None):
             raise ValueError("Either probs or logits must be specified, not both")
         if probs is not None:
-            self._param = self.probs = probs
+            self._param = self.probs = argcheck.is_tensor(probs, "probs")
         else:
-            self._param = self.logits = logits
+            self._param = self.logits = argcheck.is_tensor(logits, "logits")
         super(LogisticBernoulli, self).__init__(
             self._param.shape, validate_args=validate_args
         )
@@ -467,13 +468,15 @@ class GumbelOneHotCategorical(ConditionalStraightThrough):
         probs: Optional[torch.Tensor] = None,
         validate_args: Optional[bool] = None,
     ):
-        if (probs is None) == (logits is None):
+        if (probs is None) is (logits is None):
             raise ValueError("Either probs or logits must be specified, not both")
         if probs is not None:
+            probs = argcheck.is_tensor(probs, "probs")
             if probs.dim() < 1:
                 raise ValueError("probs must be at least 1 dimensional")
             self._param = self.probs = probs / probs.sum(-1, keepdim=True)
         else:
+            logits = argcheck.is_tensor(logits, "logits")
             if logits.dim() < 1:
                 raise ValueError("logits must be at least 1 dimensional")
             self._param = self.logits = logits.log_softmax(-1)

--- a/src/pydrobert/torch/_string.py
+++ b/src/pydrobert/torch/_string.py
@@ -699,8 +699,7 @@ class _StringMatching(torch.nn.Module, metaclass=abc.ABCMeta):
     def __init__(
         self, eos, include_eos, batch_first, ins_cost, del_cost, sub_cost, warn
     ):
-        if eos is not None:
-            eos = argcheck.is_int(eos, "eos")
+        eos = argcheck.is_int(eos, "eos", True)
         include_eos = argcheck.is_bool(include_eos, "include_eos")
         batch_first = argcheck.is_bool(batch_first, "batch_first")
         ins_cost = argcheck.is_float(ins_cost, "ins_cost")
@@ -1338,15 +1337,13 @@ class HardOptimalCompletionDistillationLoss(torch.nn.Module):
         reduction: Reduction = "mean",
         ignore_index: int = config.INDEX_PAD_VALUE,
     ):
-        if eos is not None:
-            eos = argcheck.is_int(eos, "eos")
+        eos = argcheck.is_int(eos, "eos", True)
         include_eos = argcheck.is_bool(include_eos, "include_eos")
         batch_first = argcheck.is_bool(batch_first, "batch_first")
         ins_cost = argcheck.is_float(ins_cost, "ins_cost")
         del_cost = argcheck.is_float(del_cost, "del_cost")
         sub_cost = argcheck.is_float(sub_cost, "sub_cost")
-        if weight is not None:
-            weight = argcheck.is_tensor(weight, "weight")
+        weight = argcheck.is_tensor(weight, "weight", True)
         reduction = argcheck.is_in(reduction, get_args(Reduction), "reduction")
         ignore_index = argcheck.is_int(ignore_index, "ignore_index")
         super().__init__()
@@ -1609,8 +1606,7 @@ class MinimumErrorRateLoss(torch.nn.Module):
         sub_cost: float = config.DEFT_SUB_COST,
         reduction: Literal["mean", "none", "sum"] = "mean",
     ):
-        if eos is not None:
-            eos = argcheck.is_int(eos, "eos")
+        eos = argcheck.is_int(eos, "eos", True)
         include_eos = argcheck.is_bool(include_eos, "include_eos")
         sub_avg = argcheck.is_bool(sub_avg, "sub_avg")
         batch_first = argcheck.is_bool(batch_first, "batch_first")

--- a/src/pydrobert/torch/_string.py
+++ b/src/pydrobert/torch/_string.py
@@ -16,13 +16,15 @@ import abc
 import warnings
 
 from typing import Optional, overload
-from typing_extensions import Literal
+from typing_extensions import Literal, get_args
 
 import torch
 
-from . import config
+from . import config, argcheck
 from ._compat import script
 from ._wrappers import functional_wrapper, proxy
+
+Reduction = Literal["mean", "sum", "none"]
 
 
 @functional_wrapper("FillAfterEndOfSequence")
@@ -108,17 +110,21 @@ class FillAfterEndOfSequence(torch.nn.Module):
         [-1., -1., -1., -1., -1., -1., -1., -1., -1., -1.]])
     """
 
-    __constants__ = ["eos", "dim", "fill"]
+    __constants__ = "eos", "dim", "fill"
 
     dim: int
     eos: int
     fill: float
 
     def __init__(self, eos: int, dim: int = 0, fill: Optional[float] = None) -> None:
+        eos = argcheck.is_int(eos, "eos")
+        dim = argcheck.is_int(dim, "dim")
+        if fill is None:
+            fill = float(eos)
+        else:
+            fill = argcheck.is_float(fill, "fill")
         super().__init__()
-        self.eos = eos
-        self.dim = dim
-        self.fill = float(eos) if fill is None else fill
+        self.eos, self.dim, self.fill = eos, dim, fill
 
     def forward(
         self, tokens: torch.Tensor, value: Optional[torch.Tensor] = None
@@ -672,7 +678,7 @@ sub_avg
 
 
 class _StringMatching(torch.nn.Module, metaclass=abc.ABCMeta):
-    __constants__ = [
+    __constants__ = (
         "eos",
         "include_eos",
         "batch_first",
@@ -680,7 +686,7 @@ class _StringMatching(torch.nn.Module, metaclass=abc.ABCMeta):
         "del_cost",
         "sub_cost",
         "warn",
-    ]
+    )
 
     eos: Optional[int]
     include_eos: bool
@@ -693,13 +699,17 @@ class _StringMatching(torch.nn.Module, metaclass=abc.ABCMeta):
     def __init__(
         self, eos, include_eos, batch_first, ins_cost, del_cost, sub_cost, warn
     ):
+        if eos is not None:
+            eos = argcheck.is_int(eos, "eos")
+        include_eos = argcheck.is_bool(include_eos, "include_eos")
+        batch_first = argcheck.is_bool(batch_first, "batch_first")
+        ins_cost = argcheck.is_float(ins_cost, "ins_cost")
+        del_cost = argcheck.is_float(del_cost, "del_cost")
+        sub_cost = argcheck.is_float(sub_cost, "sub_cost")
+        warn = argcheck.is_bool(warn, "warn")
         super().__init__()
-        self.eos = eos
-        self.include_eos = include_eos
-        self.batch_first = batch_first
-        self.ins_cost = ins_cost
-        self.del_cost = del_cost
-        self.sub_cost = sub_cost
+        self.eos, self.include_eos, self.batch_first = eos, include_eos, batch_first
+        self.ins_cost, self.del_cost, self.sub_cost = ins_cost, del_cost, sub_cost
         self.warn = warn
 
     def extra_repr(self) -> str:
@@ -711,7 +721,7 @@ class _StringMatching(torch.nn.Module, metaclass=abc.ABCMeta):
 
 
 class EditDistance(_StringMatching):
-    __constants__ = [
+    __constants__ = (
         "eos",
         "include_eos",
         "norm",
@@ -720,7 +730,7 @@ class EditDistance(_StringMatching):
         "del_cost",
         "sub_cost",
         "warn",
-    ]
+    )
 
     norm: bool
 
@@ -735,6 +745,7 @@ class EditDistance(_StringMatching):
         sub_cost: float = config.DEFT_SUB_COST,
         warn: bool = True,
     ):
+        norm = argcheck.is_bool(norm, "norm")
         super().__init__(
             eos, include_eos, batch_first, ins_cost, del_cost, sub_cost, warn
         )
@@ -789,7 +800,7 @@ class EditDistance(_StringMatching):
 
 class PrefixEditDistances(_StringMatching):
 
-    __constants__ = [
+    __constants__ = (
         "eos",
         "include_eos",
         "norm",
@@ -800,7 +811,7 @@ class PrefixEditDistances(_StringMatching):
         "padding",
         "exclude_last",
         "warn",
-    ]
+    )
 
     norm: bool
     padding: int
@@ -819,12 +830,13 @@ class PrefixEditDistances(_StringMatching):
         exclude_last: bool = False,
         warn: bool = True,
     ):
+        norm = argcheck.is_bool(norm, "norm")
+        padding = argcheck.is_int(padding, "padding")
+        exclude_last = argcheck.is_bool(exclude_last, "exclude_last")
         super().__init__(
             eos, include_eos, batch_first, ins_cost, del_cost, sub_cost, warn
         )
-        self.norm = norm
-        self.padding = padding
-        self.exclude_last = exclude_last
+        self.norm, self.padding, self.exclude_last = norm, padding, exclude_last
 
     __doc__ = f"""Compute the edit distance between ref and each prefix of hyp
 
@@ -875,7 +887,7 @@ class PrefixEditDistances(_StringMatching):
 
 
 class ErrorRate(_StringMatching):
-    __constants__ = [
+    __constants__ = (
         "eos",
         "include_eos",
         "norm",
@@ -884,7 +896,7 @@ class ErrorRate(_StringMatching):
         "del_cost",
         "sub_cost",
         "warn",
-    ]
+    )
 
     norm: bool
 
@@ -899,6 +911,7 @@ class ErrorRate(_StringMatching):
         sub_cost: float = config.DEFT_SUB_COST,
         warn: bool = True,
     ):
+        norm = argcheck.is_bool(norm, "norm")
         super().__init__(
             eos, include_eos, batch_first, ins_cost, del_cost, sub_cost, warn
         )
@@ -986,12 +999,13 @@ class PrefixErrorRates(_StringMatching):
         exclude_last: bool = False,
         warn: bool = True,
     ):
+        norm = argcheck.is_bool(norm, "norm")
+        padding = argcheck.is_int(padding, "padding")
+        exclude_last = argcheck.is_bool(exclude_last, "exclude_last")
         super().__init__(
             eos, include_eos, batch_first, ins_cost, del_cost, sub_cost, warn
         )
-        self.norm = norm
-        self.padding = padding
-        self.exclude_last = exclude_last
+        self.norm, self.padding, self.exclude_last = norm, padding, exclude_last
 
     __doc__ = f"""Compute the error rate between ref and each prefix of hyp
 
@@ -1037,7 +1051,7 @@ class PrefixErrorRates(_StringMatching):
 
 
 class OptimalCompletion(_StringMatching):
-    __constants__ = [
+    __constants__ = (
         "eos",
         "include_eos",
         "batch_first",
@@ -1047,7 +1061,7 @@ class OptimalCompletion(_StringMatching):
         "padding",
         "exclude_last",
         "warn",
-    ]
+    )
 
     padding: int
     exclude_last: bool
@@ -1064,11 +1078,12 @@ class OptimalCompletion(_StringMatching):
         exclude_last: bool = False,
         warn: bool = True,
     ):
+        padding = argcheck.is_int(padding, "padding")
+        exclude_last = argcheck.is_bool(exclude_last, "exclude_last")
         super().__init__(
             eos, include_eos, batch_first, ins_cost, del_cost, sub_cost, warn
         )
-        self.padding = padding
-        self.exclude_last = exclude_last
+        self.padding, self.exclude_last = padding, exclude_last
 
     __doc__ = f"""Return a mask of next tokens of a minimum edit distance prefix
     
@@ -1164,7 +1179,7 @@ def hard_optimal_completion_distillation_loss(
     del_cost: float = config.DEFT_DEL_COST,
     sub_cost: float = config.DEFT_SUB_COST,
     weight: Optional[torch.Tensor] = None,
-    reduction: Literal["mean", "sum", "none"] = "mean",
+    reduction: Reduction = "mean",
     ignore_index: int = -2,
     warn: bool = True,
 ) -> torch.Tensor:
@@ -1238,7 +1253,7 @@ def hard_optimal_completion_distillation_loss(
 
 
 class HardOptimalCompletionDistillationLoss(torch.nn.Module):
-    __constants__ = [
+    __constants__ = (
         "eos",
         "include_eos",
         "batch_first",
@@ -1247,7 +1262,7 @@ class HardOptimalCompletionDistillationLoss(torch.nn.Module):
         "sub_cost",
         "reduction",
         "ignore_index",
-    ]
+    )
 
     __doc__ = f"""A categorical loss function over optimal next tokens
 
@@ -1320,18 +1335,24 @@ class HardOptimalCompletionDistillationLoss(torch.nn.Module):
         del_cost: float = config.DEFT_DEL_COST,
         sub_cost: float = config.DEFT_SUB_COST,
         weight: Optional[torch.Tensor] = None,
-        reduction: Literal["mean", "sum", "none"] = "mean",
-        ignore_index: int = -100,
+        reduction: Reduction = "mean",
+        ignore_index: int = config.INDEX_PAD_VALUE,
     ):
+        if eos is not None:
+            eos = argcheck.is_int(eos, "eos")
+        include_eos = argcheck.is_bool(include_eos, "include_eos")
+        batch_first = argcheck.is_bool(batch_first, "batch_first")
+        ins_cost = argcheck.is_float(ins_cost, "ins_cost")
+        del_cost = argcheck.is_float(del_cost, "del_cost")
+        sub_cost = argcheck.is_float(sub_cost, "sub_cost")
+        if weight is not None:
+            weight = argcheck.is_tensor(weight, "weight")
+        reduction = argcheck.is_in(reduction, get_args(Reduction), "reduction")
+        ignore_index = argcheck.is_int(ignore_index, "ignore_index")
         super().__init__()
-        self.eos = eos
-        self.include_eos = include_eos
-        self.batch_first = batch_first
-        self.ins_cost = ins_cost
-        self.del_cost = del_cost
-        self.sub_cost = sub_cost
-        self.reduction = reduction
-        self.ignore_index = ignore_index
+        self.eos, self.include_eos, self.batch_first = eos, include_eos, batch_first
+        self.ins_cost, self.del_cost, self.sub_cost = ins_cost, del_cost, sub_cost
+        self.reduction, self.ignore_index = reduction, ignore_index
         self.register_buffer("weight", weight)
 
     def forward(
@@ -1373,7 +1394,7 @@ def minimum_error_rate_loss(
     ins_cost: float = config.DEFT_INS_COST,
     del_cost: float = config.DEFT_DEL_COST,
     sub_cost: float = config.DEFT_SUB_COST,
-    reduction: Literal["mean", "sum", "none"] = "mean",
+    reduction: Reduction = "mean",
     warn: bool = True,
 ) -> torch.Tensor:
     ...
@@ -1456,7 +1477,7 @@ def minimum_error_rate_loss(
 
 class MinimumErrorRateLoss(torch.nn.Module):
 
-    __constants__ = [
+    __constants__ = (
         "eos",
         "include_eos",
         "sub_avg",
@@ -1466,7 +1487,7 @@ class MinimumErrorRateLoss(torch.nn.Module):
         "del_cost",
         "sub_cost",
         "reduction",
-    ]
+    )
 
     __doc__ = f"""Error rate expectation normalized over some number of transcripts
 
@@ -1588,16 +1609,22 @@ class MinimumErrorRateLoss(torch.nn.Module):
         sub_cost: float = config.DEFT_SUB_COST,
         reduction: Literal["mean", "none", "sum"] = "mean",
     ):
+        if eos is not None:
+            eos = argcheck.is_int(eos, "eos")
+        include_eos = argcheck.is_bool(include_eos, "include_eos")
+        sub_avg = argcheck.is_bool(sub_avg, "sub_avg")
+        batch_first = argcheck.is_bool(batch_first, "batch_first")
+        norm = argcheck.is_bool(norm, "norm")
+        ins_cost = argcheck.is_float(ins_cost, "ins_cost")
+        del_cost = argcheck.is_float(del_cost, "del_cost")
+        sub_cost = argcheck.is_float(sub_cost, "sub_cost")
+        if weight is not None:
+            weight = argcheck.is_tensor(weight, "weight")
+        reduction = argcheck.is_in(reduction, get_args(Reduction), "reduction")
         super().__init__()
-        self.eos = eos
-        self.include_eos = include_eos
-        self.sub_avg = sub_avg
-        self.batch_first = batch_first
-        self.norm = norm
-        self.ins_cost = ins_cost
-        self.del_cost = del_cost
-        self.sub_cost = sub_cost
-        self.reduction = reduction
+        self.eos, self.include_eos, self.sub_avg = eos, include_eos, sub_avg
+        self.batch_first, self.norm, self.reduction = batch_first, norm, reduction
+        self.ins_cost, self.del_cost, self.sub_cost = ins_cost, del_cost, sub_cost
 
     def forward(
         self,

--- a/src/pydrobert/torch/_string.py
+++ b/src/pydrobert/torch/_string.py
@@ -1618,8 +1618,6 @@ class MinimumErrorRateLoss(torch.nn.Module):
         ins_cost = argcheck.is_float(ins_cost, "ins_cost")
         del_cost = argcheck.is_float(del_cost, "del_cost")
         sub_cost = argcheck.is_float(sub_cost, "sub_cost")
-        if weight is not None:
-            weight = argcheck.is_tensor(weight, "weight")
         reduction = argcheck.is_in(reduction, get_args(Reduction), "reduction")
         super().__init__()
         self.eos, self.include_eos, self.sub_avg = eos, include_eos, sub_avg

--- a/src/pydrobert/torch/_wrappers.py
+++ b/src/pydrobert/torch/_wrappers.py
@@ -33,8 +33,10 @@ pydrobert.torch.modules.{module_name}
     For a description of what this does, its inputs, and its outputs.
 """
 
+C = TypeVar("C", bound=Callable)
 
-def functional_wrapper(module_name: str):
+
+def functional_wrapper(module_name: str) -> Callable[[C], C]:
     def decorator(func):
         sig = signature(func)
         parameters = "\n".join(sig.parameters)
@@ -55,9 +57,6 @@ Returns
     decorator.__modname = module_name
 
     return decorator
-
-
-C = TypeVar("C", bound=Callable)
 
 
 def proxy(f: C) -> C:

--- a/src/pydrobert/torch/argcheck.py
+++ b/src/pydrobert/torch/argcheck.py
@@ -1,0 +1,238 @@
+# Copyright 2023 Sean Robertson
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Boilerplate for checking argument values"""
+
+import os
+
+from typing import Optional, TypeVar, Type, Callable, Any, Collection
+from pathlib import Path
+from typing_extensions import ParamSpec, Concatenate
+
+import torch
+
+V = TypeVar("V")
+P = ParamSpec("P")
+StrPathLike = TypeVar("StrPathLike", str, os.PathLike, Path)
+
+
+def _nv(name: Optional[str], val) -> str:
+    return f"'{val}'" if name is None else f"{name} ('{val}')"
+
+
+def _simple_check_factory(t: Type[V], *ts: Type[Any]):
+    ts = (t,) + ts
+    suf = "n" if t.__name__.startswith(("a", "e", "i", "o", "u")) else ""
+
+    def _check(val: V, *args, name: Optional[str] = None, **kwargs) -> V:
+        if not isinstance(val, ts):
+            raise ValueError(f"{_nv(name, val)} is not a{suf} {t.__name__}")
+        return val
+
+    return _check
+
+
+is_str = _simple_check_factory(str)
+is_int = _simple_check_factory(int)
+is_bool = _simple_check_factory(bool)
+is_float = _simple_check_factory(float, int)
+is_pathlike = _simple_check_factory(os.PathLike)
+is_path = _simple_check_factory(Path)
+
+
+def _chain_factory(
+    *checks: Callable[Concatenate[V, P], V]
+) -> Callable[Concatenate[V, P], V]:
+    def _chain(val: V, *args, **kwargs) -> V:
+        for check in checks:
+            val = check(val, *args, **kwargs)
+        return val
+
+    return _chain
+
+
+def is_pos(val: V, *args, name: Optional[str] = None, **kwargs) -> V:
+    if val <= 0:
+        raise ValueError(f"{_nv(name, val)} is not positive")
+    return val
+
+
+is_posf = _chain_factory(is_float, is_pos)
+is_nat = is_posi = _chain_factory(is_int, is_pos)
+
+
+def is_nonneg(val: V, *args, name: Optional[str] = None, **kwargs) -> V:
+    if val < 0:
+        raise ValueError(f"{_nv(name, val)} is negative")
+    return val
+
+
+is_nonnegf = _chain_factory(is_float, is_nonneg)
+is_nonnegi = _chain_factory(is_int, is_nonneg)
+
+
+def is_neg(val: V, *args, name: Optional[str] = None, **kwargs) -> V:
+    if val >= 0:
+        raise ValueError(f"{_nv(name, val)} is not negative")
+    return val
+
+
+is_negf = _chain_factory(is_float, is_nonneg)
+is_negi = _chain_factory(is_int, is_nonneg)
+
+
+def is_nonpos(val: V, *args, name: Optional[str] = None, **kwargs) -> V:
+    if val > 0:
+        raise ValueError(f"{_nv(name, val)} is positive")
+    return val
+
+
+is_nonposf = _chain_factory(is_float, is_nonpos)
+is_nonposi = _chain_factory(is_int, is_nonpos)
+
+
+def is_lt(
+    val: V,
+    other,
+    *args,
+    name: Optional[str] = None,
+    other_name: Optional[str] = None,
+    inclusive: bool = False,
+    **kwargs,
+) -> V:
+    if inclusive and val > other:
+        raise ValueError(f"{_nv(name, val)} is greater than {_nv(other_name, other)}")
+    elif val >= other:
+        raise ValueError(
+            f"{_nv(name, val)} is greater than or equal to {_nv(other_name, other)}"
+        )
+    return val
+
+
+is_ltf = _chain_factory(is_float, is_lt)
+is_lti = _chain_factory(is_int, is_lt)
+
+
+def is_gt(
+    val: V,
+    other,
+    *args,
+    name: Optional[str] = None,
+    other_name: Optional[str] = None,
+    inclusive: bool = False,
+    **kwargs,
+) -> V:
+    if inclusive and val < other:
+        raise ValueError(f"{_nv(name, val)} is less than {_nv(other_name, other)}")
+    elif val <= other:
+        raise ValueError(
+            f"{_nv(name, val)} is less than or equal to {_nv(other_name, other)}"
+        )
+    return val
+
+
+is_gtf = _chain_factory(is_float, is_gt)
+is_gti = _chain_factory(is_int, is_gt)
+
+
+def is_btw(
+    val: V,
+    left,
+    right,
+    *args,
+    name: Optional[str] = None,
+    left_name: Optional[str] = None,
+    right_name: Optional[str] = None,
+    left_inclusive: bool = False,
+    right_inclusive: bool = False,
+    **kwargs,
+) -> V:
+    val = is_gt(val, left, name=name, other_name=left_name, inclusive=left_inclusive)
+    val = is_lt(val, right, name=name, other_name=right_name, inclusive=right_inclusive)
+    return val
+
+
+is_btwf = _chain_factory(is_float, is_btw)
+is_btwi = _chain_factory(is_int, is_btw)
+
+
+def is_mag(val: float, *args, **kwargs) -> float:
+    return is_btwf(val, 0, 1, *args, **kwargs)
+
+
+is_open01 = is_mag
+
+
+def is_closed01(val: float, *args, **kwargs) -> float:
+    return is_btwf(
+        val, 0, 1, *args, inclusive_left=True, inclusive_right=True, **kwargs
+    )
+
+
+def is_file(val: StrPathLike, *args, name: Optional[str], **kwargs) -> StrPathLike:
+    if not os.path.isfile(val):
+        raise ValueError(f"{_nv(name, val)} is not a file")
+    return val
+
+
+def is_dir(val: StrPathLike, *args, name: Optional[str], **kwargs) -> StrPathLike:
+    if not os.path.isdir(val):
+        raise ValueError(f"{_nv(name, val)} is not a directory")
+    return val
+
+
+def is_in(
+    val: V, choices: Collection[V], *args, name: Optional[str] = None, **kwargs
+) -> V:
+    if val not in choices:
+        raise ValueError(f"{_nv(name, val)} not in '{choices}'")
+    return val
+
+
+def _cast_factory(cast: Callable[[Any], V], *checks: Callable[Concatenate[V, P], V]):
+    def _cast(val: Any, *args, name: Optional[str] = None, **kwargs) -> V:
+        try:
+            val = cast(val)
+        except:
+            raise ValueError(f"Could not cast {_nv(name, val)} as {cast.__name__}")
+        for check in checks:
+            val = check(val, *args, name=name, **kwargs)
+        return val
+
+    return _cast
+
+
+as_str = _cast_factory(str)
+as_int = _cast_factory(int)
+as_bool = _cast_factory(bool)
+as_float = _cast_factory(float)
+as_posf = _cast_factory(float, is_pos)
+as_nat = as_posi = _cast_factory(int, is_pos)
+as_nonnegf = _cast_factory(float, is_nonneg)
+as_nonnegi = _cast_factory(int, is_nonneg)
+as_negf = _cast_factory(float, is_neg)
+as_negi = _cast_factory(int, is_neg)
+as_nonposf = _cast_factory(float, is_nonpos)
+as_nonposi = _cast_factory(int, is_nonpos)
+as_ltf = _cast_factory(float, is_lt)
+as_lti = _cast_factory(int, is_lt)
+as_gtf = _cast_factory(float, is_gt)
+as_gti = _cast_factory(int, is_gt)
+as_mag = as_open01 = _cast_factory(float, is_mag)
+as_closed01 = _cast_factory(float, is_closed01)
+as_path = _cast_factory(Path)
+as_path_file = _cast_factory(Path, is_file)
+as_path_dir = _cast_factory(Path, is_dir)
+as_file = _cast_factory(str, is_file)
+as_dir = _cast_factory(str, is_dir)

--- a/src/pydrobert/torch/argcheck.py
+++ b/src/pydrobert/torch/argcheck.py
@@ -32,7 +32,12 @@ from typing_extensions import ParamSpec, Concatenate
 
 import torch
 
-from ._compat import script
+from ._compat import _v, script as _script
+
+if _v < "1.10.0":
+    script = torch.jit.ignore(drop=True)
+else:
+    script = _script
 
 V = TypeVar("V")
 P = ParamSpec("P")

--- a/src/pydrobert/torch/argcheck.py
+++ b/src/pydrobert/torch/argcheck.py
@@ -15,200 +15,597 @@
 """Boilerplate for checking argument values"""
 
 import os
+import string
 
-from typing import Optional, TypeVar, Type, Callable, Any, Collection
+from typing import (
+    Optional,
+    TypeVar,
+    Callable,
+    Any,
+    Collection,
+    Type,
+    List,
+    TYPE_CHECKING,
+)
 from pathlib import Path
 from typing_extensions import ParamSpec, Concatenate
 
 import torch
 
+from ._compat import script
+
 V = TypeVar("V")
 P = ParamSpec("P")
+NumLike = TypeVar("NumLike", float, int, torch.Tensor)
 StrPathLike = TypeVar("StrPathLike", str, os.PathLike, Path)
 
 
-def _nv(name: Optional[str], val) -> str:
-    return f"'{val}'" if name is None else f"{name} ('{val}')"
+@script
+def _nv(name: Optional[str], val: Any) -> str:
+    if isinstance(val, torch.Tensor):
+        if val.numel() == 1:
+            return f"{val.item()}" if name is None else f"{name} ({val.item()})"
+        else:
+            return name if name is not None else "tensor"
+    else:
+        if isinstance(val, str):
+            val = f"'{val}'"
+        return f"{val}" if name is None else f"{name} ({val})"
 
 
-def _simple_check_factory(t: Type[V], *ts: Type[Any]):
+def _is_check_factory(t: Type[V], *ts: type):
     ts = (t,) + ts
     suf = "n" if t.__name__.startswith(("a", "e", "i", "o", "u")) else ""
 
-    def _check(val: V, *args, name: Optional[str] = None, **kwargs) -> V:
-        if not isinstance(val, ts):
+    @script
+    def _is_check(val: t, name: Optional[str] = None) -> t:
+        if torch.jit.is_scripting():
+            return val
+        elif isinstance(val, ts):
+            return val if isinstance(val, t) else t(val)
+        else:
             raise ValueError(f"{_nv(name, val)} is not a{suf} {t.__name__}")
+
+    return _is_check
+
+
+is_str = _is_check_factory(str)
+is_int = _is_check_factory(int)
+is_bool = _is_check_factory(bool, int, float)
+is_float = _is_check_factory(float, int)
+is_pathlike = _is_check_factory(os.PathLike)
+is_path = _is_check_factory(Path)
+is_tensor = _is_check_factory(torch.Tensor)
+
+
+def _is_numcheck_factory(t: Type[NumLike], *ts: Type[NumLike]):
+    ts = (t,) + ts
+
+    @script
+    def _is_poscheck(val: t, name: Optional[str] = None) -> t:
+        if not torch.jit.is_scripting():
+            if isinstance(val, ts):
+                val = t(val)
+            else:
+                raise ValueError(f"{_nv(name, val)} is not a positive {t.__name__}")
+        if val <= 0:
+            raise ValueError(f"{_nv(name, val)} is not a positive {t.__name__}")
         return val
 
-    return _check
-
-
-is_str = _simple_check_factory(str)
-is_int = _simple_check_factory(int)
-is_bool = _simple_check_factory(bool)
-is_float = _simple_check_factory(float, int)
-is_pathlike = _simple_check_factory(os.PathLike)
-is_path = _simple_check_factory(Path)
-
-
-def _chain_factory(
-    *checks: Callable[Concatenate[V, P], V]
-) -> Callable[Concatenate[V, P], V]:
-    def _chain(val: V, *args, **kwargs) -> V:
-        for check in checks:
-            val = check(val, *args, **kwargs)
+    @script
+    def _is_negcheck(val: t, name: Optional[str] = None) -> t:
+        if not torch.jit.is_scripting():
+            if isinstance(val, ts):
+                val = t(val)
+            else:
+                raise ValueError(f"{_nv(name, val)} is not a negative {t.__name__}")
+        if val >= 0:
+            raise ValueError(f"{_nv(name, val)} is not a negative {t.__name__}")
         return val
 
-    return _chain
+    @script
+    def _is_nonposcheck(val: t, name: Optional[str] = None) -> t:
+        if not torch.jit.is_scripting():
+            if isinstance(val, ts):
+                val = t(val)
+            else:
+                raise ValueError(f"{_nv(name, val)} is not a non-positive {t.__name__}")
+        if val > 0:
+            raise ValueError(f"{_nv(name, val)} is not a non-positive {t.__name__}")
+        return val
+
+    @script
+    def _is_nonnegcheck(val: t, name: Optional[str] = None) -> t:
+        if not torch.jit.is_scripting():
+            if isinstance(val, ts):
+                val = t(val)
+            else:
+                raise ValueError(f"{_nv(name, val)} is not a non-negative {t.__name__}")
+        if val < 0:
+            raise ValueError(f"{_nv(name, val)} is not a non-negative {t.__name__}")
+        return val
+
+    return _is_poscheck, _is_negcheck, _is_nonposcheck, _is_nonnegcheck
 
 
-def is_pos(val: V, *args, name: Optional[str] = None, **kwargs) -> V:
-    if val <= 0:
-        raise ValueError(f"{_nv(name, val)} is not positive")
+is_posi, is_negi, is_nonposi, is_nonnegi = _is_numcheck_factory(int)
+is_nat = is_posi
+is_posf, is_negf, is_nonposf, is_nonnegf = _is_numcheck_factory(float, int)
+
+
+@script
+def is_post(val: torch.Tensor, name: Optional[str] = None) -> torch.Tensor:
+    if not torch.jit.is_scripting():
+        if not isinstance(val, torch.Tensor):
+            raise ValueError(
+                f"{_nv(name, val)} is not a tensor of only positive values"
+            )
+    if (val <= 0).any():
+        raise ValueError(f"{_nv(name, val)} is not a tensor of only positive values")
     return val
 
 
-is_posf = _chain_factory(is_float, is_pos)
-is_nat = is_posi = _chain_factory(is_int, is_pos)
-
-
-def is_nonneg(val: V, *args, name: Optional[str] = None, **kwargs) -> V:
-    if val < 0:
-        raise ValueError(f"{_nv(name, val)} is negative")
+@script
+def is_negt(val: torch.Tensor, name: Optional[str] = None) -> torch.Tensor:
+    if not torch.jit.is_scripting():
+        if not isinstance(val, torch.Tensor):
+            raise ValueError(
+                f"{_nv(name, val)} is not a tensor of only negative values"
+            )
+    if (val >= 0).any():
+        raise ValueError(f"{_nv(name, val)} is not a tensor of only negative values")
     return val
 
 
-is_nonnegf = _chain_factory(is_float, is_nonneg)
-is_nonnegi = _chain_factory(is_int, is_nonneg)
-
-
-def is_neg(val: V, *args, name: Optional[str] = None, **kwargs) -> V:
-    if val >= 0:
-        raise ValueError(f"{_nv(name, val)} is not negative")
-    return val
-
-
-is_negf = _chain_factory(is_float, is_nonneg)
-is_negi = _chain_factory(is_int, is_nonneg)
-
-
-def is_nonpos(val: V, *args, name: Optional[str] = None, **kwargs) -> V:
-    if val > 0:
-        raise ValueError(f"{_nv(name, val)} is positive")
-    return val
-
-
-is_nonposf = _chain_factory(is_float, is_nonpos)
-is_nonposi = _chain_factory(is_int, is_nonpos)
-
-
-def is_lt(
-    val: V,
-    other,
-    *args,
-    name: Optional[str] = None,
-    other_name: Optional[str] = None,
-    inclusive: bool = False,
-    **kwargs,
-) -> V:
-    if inclusive and val > other:
-        raise ValueError(f"{_nv(name, val)} is greater than {_nv(other_name, other)}")
-    elif val >= other:
+@script
+def is_nonpost(val: torch.Tensor, name: Optional[str] = None) -> torch.Tensor:
+    if not torch.jit.is_scripting():
+        if not isinstance(val, torch.Tensor):
+            raise ValueError(
+                f"{_nv(name, val)} is not a tensor of only non-positive values"
+            )
+    if (val > 0).any():
         raise ValueError(
-            f"{_nv(name, val)} is greater than or equal to {_nv(other_name, other)}"
+            f"{_nv(name, val)} is not a tensor of only non-positive values"
         )
     return val
 
 
-is_ltf = _chain_factory(is_float, is_lt)
-is_lti = _chain_factory(is_int, is_lt)
-
-
-def is_gt(
-    val: V,
-    other,
-    *args,
-    name: Optional[str] = None,
-    other_name: Optional[str] = None,
-    inclusive: bool = False,
-    **kwargs,
-) -> V:
-    if inclusive and val < other:
-        raise ValueError(f"{_nv(name, val)} is less than {_nv(other_name, other)}")
-    elif val <= other:
+@script
+def is_nonnegt(val: torch.Tensor, name: Optional[str] = None) -> torch.Tensor:
+    if not torch.jit.is_scripting():
+        if not isinstance(val, torch.Tensor):
+            raise ValueError(
+                f"{_nv(name, val)} is not a tensor of only non-negative values"
+            )
+    if (val < 0).any():
         raise ValueError(
-            f"{_nv(name, val)} is less than or equal to {_nv(other_name, other)}"
+            f"{_nv(name, val)} is not a tensor of only non-negative values"
         )
     return val
 
 
-is_gtf = _chain_factory(is_float, is_gt)
-is_gti = _chain_factory(is_int, is_gt)
-
-
-def is_btw(
-    val: V,
-    left,
-    right,
-    *args,
+@script
+def is_token(
+    val: str,
     name: Optional[str] = None,
-    left_name: Optional[str] = None,
-    right_name: Optional[str] = None,
-    left_inclusive: bool = False,
-    right_inclusive: bool = False,
-    **kwargs,
-) -> V:
-    val = is_gt(val, left, name=name, other_name=left_name, inclusive=left_inclusive)
-    val = is_lt(val, right, name=name, other_name=right_name, inclusive=right_inclusive)
+    empty_okay: bool = False,
+    whitespace: str = string.whitespace,
+) -> str:
+    if not empty_okay and not len(val):
+        raise ValueError(f"{_nv(name, val)} is empty")
+    else:
+        for w in whitespace:
+            if w in val:
+                raise ValueError(f"{_nv(name, val)} contains '{w}'")
     return val
 
 
-is_btwf = _chain_factory(is_float, is_btw)
-is_btwi = _chain_factory(is_int, is_btw)
+@torch.jit.unused
+def is_a(val: V, t: Type[V], name: Optional[str] = None) -> V:
+    if not isinstance(val, t):
+        suf = "n" if t.__name__.startswith(("a", "e", "i", "o", "u")) else ""
+        raise ValueError(f"{_nv(name, val)} is not a{suf} {t.__name__}")
+    return val
 
 
-def is_mag(val: float, *args, **kwargs) -> float:
-    return is_btwf(val, 0, 1, *args, **kwargs)
+if TYPE_CHECKING:
+
+    def is_pos(val: NumLike, name: Optional[str] = None) -> NumLike:
+        ...
+
+    def is_neg(val: NumLike, name: Optional[str] = None) -> NumLike:
+        ...
+
+    def is_nonpos(val: NumLike, name: Optional[str] = None) -> NumLike:
+        ...
+
+    def is_nonneg(val: NumLike, name: Optional[str] = None) -> NumLike:
+        ...
+
+    def is_equal(
+        val: NumLike,
+        other: NumLike,
+        name: Optional[str] = None,
+        other_name: Optional[str] = None,
+    ) -> NumLike:
+        ...
+
+    def is_exactly(
+        val: V,
+        other: Any,
+        name: Optional[str] = None,
+        other_name: Optional[str] = None,
+    ) -> V:
+        ...
+
+    def is_lt(
+        val: NumLike,
+        other: NumLike,
+        name: Optional[str] = None,
+        other_name: Optional[str] = None,
+        inclusive: bool = False,
+    ) -> NumLike:
+        ...
+
+    def is_lte(
+        val: NumLike,
+        other: NumLike,
+        name: Optional[str] = None,
+        other_name: Optional[str] = None,
+    ) -> NumLike:
+        ...
+
+    def is_gt(
+        val: NumLike,
+        other: NumLike,
+        name: Optional[str] = None,
+        other_name: Optional[str] = None,
+        inclusive: bool = False,
+    ) -> NumLike:
+        ...
+
+    def is_gte(
+        val: NumLike,
+        other: NumLike,
+        name: Optional[str] = None,
+        other_name: Optional[str] = None,
+    ) -> NumLike:
+        ...
+
+    def is_btw(
+        val: NumLike,
+        left: NumLike,
+        right: NumLike,
+        name: Optional[str] = None,
+        left_name: Optional[str] = None,
+        right_name: Optional[str] = None,
+        left_inclusive: bool = False,
+        right_inclusive: bool = False,
+    ) -> NumLike:
+        ...
+
+    def is_in(val: V, choices: Collection[Any], name: Optional[str] = None) -> V:
+        ...
 
 
-is_open01 = is_mag
+else:
+
+    @script
+    def is_pos(val: Any, name: Optional[str] = None) -> Any:
+        okay: Optional[bool] = None
+        if isinstance(val, torch.Tensor):
+            okay = bool((val > 0).all().item())
+        if isinstance(val, (float, int)):
+            okay = val > 0
+        if okay is None:
+            raise TypeError("type not implemented for is_pos")
+        elif not okay:
+            raise ValueError(f"{_nv(name, val)} is not positive")
+        return val
+
+    @script
+    def is_neg(val: Any, name: Optional[str] = None) -> Any:
+        okay: Optional[bool] = None
+        if isinstance(val, torch.Tensor):
+            okay = bool((val < 0).all().item())
+        if isinstance(val, (float, int)):
+            okay = val < 0
+        if okay is None:
+            raise TypeError("type not implemented for is_neg")
+        elif not okay:
+            raise ValueError(f"{_nv(name, val)} is not negative")
+        return val
+
+    @script
+    def is_nonpos(val: Any, name: Optional[str] = None) -> Any:
+        okay: Optional[bool] = None
+        if isinstance(val, torch.Tensor):
+            okay = bool((val <= 0).all().item())
+        if isinstance(val, (float, int)):
+            okay = val <= 0
+        if okay is None:
+            raise TypeError("type not implemented for is_nonpos")
+        elif not okay:
+            raise ValueError(f"{_nv(name, val)} is positive")
+        return val
+
+    @script
+    def is_nonneg(val: Any, name: Optional[str] = None) -> Any:
+        okay: Optional[bool] = None
+        if isinstance(val, torch.Tensor):
+            okay = bool((val >= 0).all().item())
+        if isinstance(val, (float, int)):
+            okay = val >= 0
+        if okay is None:
+            raise TypeError("type not implemented for is_nonneg")
+        elif not okay:
+            raise ValueError(f"{_nv(name, val)} is not negative")
+        return val
+
+    @script
+    def is_equal(
+        val: Any,
+        other: Any,
+        name: Optional[str] = None,
+        other_name: Optional[str] = None,
+    ) -> Any:
+        okay: Optional[bool] = None
+        if isinstance(val, torch.Tensor) and isinstance(other, torch.Tensor):
+            okay = bool((val == other).all().item())
+        if isinstance(val, torch.Tensor) and isinstance(other, (int, float)):
+            okay = bool((val == other).all().item())
+        if isinstance(other, torch.Tensor) and isinstance(val, (int, float)):
+            okay = bool((other == val).all().item())
+        if isinstance(val, (float, int)) and isinstance(other, (float, int)):
+            okay = float(val) == float(other)
+        if okay is None:
+            raise TypeError("type not implemented for is_equal")
+        elif not okay:
+            raise ValueError(
+                f"{_nv(name, val)} does not equal {_nv(other_name, other)}"
+            )
+        return val
+
+    @script
+    def is_exactly(
+        val: Any,
+        other: Any,
+        name: Optional[str] = None,
+        other_name: Optional[str] = None,
+    ) -> Any:
+        if val is not other:
+            raise ValueError(f"{_nv(name, val)} is not {_nv(other_name, other)}")
+        return val
+
+    @script
+    def is_lt(
+        val: Any,
+        other: Any,
+        name: Optional[str] = None,
+        other_name: Optional[str] = None,
+        inclusive: bool = False,
+    ) -> Any:
+        okay: Optional[bool] = None
+        comp = ">"
+        if inclusive:
+            if isinstance(val, torch.Tensor) and isinstance(other, torch.Tensor):
+                okay = bool((val <= other).all().item())
+            if isinstance(val, torch.Tensor) and isinstance(other, (float, int)):
+                okay = bool((val <= other).all().item())
+            if isinstance(other, torch.Tensor) and isinstance(val, (float, int)):
+                okay = bool((other >= val).all().item())
+            if isinstance(val, (float, int)) and isinstance(other, (float, int)):
+                okay = float(val) <= float(other)
+        else:
+            comp = ">="
+            if isinstance(val, torch.Tensor) and isinstance(other, torch.Tensor):
+                okay = bool((val < other).all().item())
+            if isinstance(val, torch.Tensor) and isinstance(other, (float, int)):
+                okay = bool((val < other).all().item())
+            if isinstance(other, torch.Tensor) and isinstance(val, (float, int)):
+                okay = bool((other > val).all().item())
+            if isinstance(val, (float, int)) and isinstance(other, (float, int)):
+                okay = float(val) < float(other)
+        if okay is None:
+            raise TypeError("type not implemented for is_lt")
+        if not okay:
+            raise ValueError(f"{_nv(name, val)} {comp} {_nv(other_name, other)}")
+        return val
+
+    def is_lte(
+        val: Any,
+        other: Any,
+        name: Optional[str] = None,
+        other_name: Optional[str] = None,
+    ) -> Any:
+        return is_lt(val, other, name, other_name, True)
+
+    @script
+    def is_gt(
+        val: Any,
+        other: Any,
+        name: Optional[str] = None,
+        other_name: Optional[str] = None,
+        inclusive: bool = False,
+    ) -> Any:
+        okay: Optional[bool] = None
+        comp = "<"
+        if inclusive:
+            if isinstance(val, torch.Tensor) and isinstance(other, torch.Tensor):
+                okay = bool((val >= other).all().item())
+            if isinstance(val, torch.Tensor) and isinstance(other, (float, int)):
+                okay = bool((val >= other).all().item())
+            if isinstance(other, torch.Tensor) and isinstance(val, (float, int)):
+                okay = bool((other <= val).all().item())
+            if isinstance(val, (float, int)) and isinstance(other, (float, int)):
+                okay = float(val) >= float(other)
+        else:
+            comp = "<="
+            if isinstance(val, torch.Tensor) and isinstance(other, torch.Tensor):
+                okay = bool((val > other).all().item())
+            if isinstance(val, torch.Tensor) and isinstance(other, (float, int)):
+                okay = bool((val > other).all().item())
+            if isinstance(other, torch.Tensor) and isinstance(val, (float, int)):
+                okay = bool((other < val).all().item())
+            if isinstance(val, (float, int)) and isinstance(other, (float, int)):
+                okay = float(val) > float(other)
+        if okay is None:
+            raise TypeError("type not implemented for is_gt")
+        if not okay:
+            raise ValueError(f"{_nv(name, val)} {comp} {_nv(other_name, other)}")
+        return val
+
+    def is_gte(
+        val: Any,
+        other: Any,
+        name: Optional[str] = None,
+        other_name: Optional[str] = None,
+    ) -> Any:
+        return is_gt(val, other, name, other_name, True)
+
+    def is_btw(
+        val: Any,
+        left: Any,
+        right: Any,
+        name: Optional[str] = None,
+        left_name: Optional[str] = None,
+        right_name: Optional[str] = None,
+        left_inclusive: bool = False,
+        right_inclusive: bool = False,
+    ) -> Any:
+        is_lt(val, right, name, right_name, right_inclusive)
+        is_gt(val, left, name, left_name, left_inclusive)
+        return val
+
+    @script
+    def is_in(val: Any, choices: List[Any], name: Optional[str] = None) -> Any:
+        okay: bool = False
+        if torch.jit.is_scripting():
+            for choice in choices:
+                if val is choice:
+                    okay = True
+        else:
+            okay = val in choices
+        if not okay:
+            raise ValueError(f"{_nv(name, val)} not in {list(choices)}")
+        return val
 
 
-def is_closed01(val: float, *args, **kwargs) -> float:
-    return is_btwf(
-        val, 0, 1, *args, inclusive_left=True, inclusive_right=True, **kwargs
-    )
+def is_posi(val: int, name: Optional[str] = None) -> int:
+    return val
 
 
-def is_file(val: StrPathLike, *args, name: Optional[str], **kwargs) -> StrPathLike:
+is_nat = is_posi
+
+
+def is_negi(val: int, name: Optional[str] = None) -> int:
+    val = is_int(val, name)
+    is_neg(val, name)
+    return val
+
+
+def is_nonposi(val: int, name: Optional[str] = None) -> int:
+    val = is_int(val, name)
+    is_nonpos(val, name)
+    return val
+
+
+def is_nonnegi(val: int, name: Optional[str] = None) -> int:
+    val = is_int(val, name)
+    is_nonneg(val, name)
+    return val
+
+
+def is_posi(val: int, name: Optional[str] = None) -> int:
+    val = is_int(val, name)
+    is_pos(val, name)
+    return val
+
+
+is_nat = is_posi
+
+
+def is_negi(val: int, name: Optional[str] = None) -> int:
+    val = is_int(val, name)
+    is_neg(val, name)
+    return val
+
+
+def is_nonposi(val: int, name: Optional[str] = None) -> int:
+    val = is_int(val, name)
+    is_nonpos(val, name)
+    return val
+
+
+def is_nonnegi(val: int, name: Optional[str] = None) -> int:
+    val = is_int(val, name)
+    is_nonneg(val, name)
+    return val
+
+
+def is_open01(val: float, name: Optional[str] = None) -> float:
+    is_float(val, name)
+    is_btw(val, 0.0, 1.0, name)
+    return val
+
+
+def is_closed01(val: float, name: Optional[str] = None) -> float:
+    is_float(val, name)
+    is_btw(val, 0.0, 1.0, name, left_inclusive=True, right_inclusive=True)
+    return val
+
+
+@torch.jit.unused
+def is_file(val: StrPathLike, name: Optional[str] = None) -> StrPathLike:
     if not os.path.isfile(val):
         raise ValueError(f"{_nv(name, val)} is not a file")
     return val
 
 
-def is_dir(val: StrPathLike, *args, name: Optional[str], **kwargs) -> StrPathLike:
+@torch.jit.unused
+def is_dir(val: StrPathLike, name: Optional[str] = None) -> StrPathLike:
     if not os.path.isdir(val):
         raise ValueError(f"{_nv(name, val)} is not a directory")
     return val
 
 
-def is_in(
-    val: V, choices: Collection[V], *args, name: Optional[str] = None, **kwargs
-) -> V:
-    if val not in choices:
-        raise ValueError(f"{_nv(name, val)} not in '{choices}'")
+@script
+def has_ndim(val: torch.Tensor, ndim: int, name: str = "tensor") -> torch.Tensor:
+    if val.ndim != ndim:
+        raise ValueError(
+            f"Expected {_nv(name, val)} to have dimension {ndim}; got {val.ndim}"
+        )
     return val
 
 
-def _cast_factory(cast: Callable[[Any], V], *checks: Callable[Concatenate[V, P], V]):
-    def _cast(val: Any, *args, name: Optional[str] = None, **kwargs) -> V:
+@script
+def is_nonempty(val: torch.Tensor, name: str = "tensor") -> torch.Tensor:
+    if not val.numel():
+        raise ValueError(f"Expected {name} to be nonempty")
+    return val
+
+
+def _cast_factory(
+    cast: Callable[[Any], V],
+    check: Optional[Callable[[V, Optional[str]], V]] = None,
+    cast_name: Optional[str] = None,
+):
+    @torch.jit.unused
+    def _cast(val: Any, name: Optional[str] = None) -> V:
         try:
             val = cast(val)
         except:
-            raise ValueError(f"Could not cast {_nv(name, val)} as {cast.__name__}")
-        for check in checks:
-            val = check(val, *args, name=name, **kwargs)
+            suf = "n" if _cast.__name__.startswith(("a", "e", "i", "o", "u")) else ""
+            raise TypeError(
+                f"Could not cast {_nv(name, val)} as a{suf} {_cast.__name__}"
+            )
+        if _cast.check is not None:
+            val = _cast.check(val, name)
         return val
+
+    _cast.check = check
+    _cast.__name__ = cast.__name__ if cast_name is None else cast_name
 
     return _cast
 
@@ -217,22 +614,23 @@ as_str = _cast_factory(str)
 as_int = _cast_factory(int)
 as_bool = _cast_factory(bool)
 as_float = _cast_factory(float)
-as_posf = _cast_factory(float, is_pos)
-as_nat = as_posi = _cast_factory(int, is_pos)
-as_nonnegf = _cast_factory(float, is_nonneg)
-as_nonnegi = _cast_factory(int, is_nonneg)
-as_negf = _cast_factory(float, is_neg)
-as_negi = _cast_factory(int, is_neg)
-as_nonposf = _cast_factory(float, is_nonpos)
-as_nonposi = _cast_factory(int, is_nonpos)
+as_posf = _cast_factory(float, is_pos, cast_name="positive float")
+as_nat = _cast_factory(int, is_pos, cast_name="natural number")
+as_posi = _cast_factory(int, is_pos, cast_name="positive integer")
+as_nonnegf = _cast_factory(float, is_nonneg, cast_name="non-negative float")
+as_nonnegi = _cast_factory(int, is_nonneg, cast_name="non-negative integer")
+as_negf = _cast_factory(float, is_neg, cast_name="negative float")
+as_negi = _cast_factory(int, is_neg, cast_name="negative integer")
+as_nonposf = _cast_factory(float, is_nonpos, cast_name="non-positive float")
+as_nonposi = _cast_factory(int, is_nonpos, cast_name="non-positive integer")
 as_ltf = _cast_factory(float, is_lt)
 as_lti = _cast_factory(int, is_lt)
 as_gtf = _cast_factory(float, is_gt)
 as_gti = _cast_factory(int, is_gt)
-as_mag = as_open01 = _cast_factory(float, is_mag)
-as_closed01 = _cast_factory(float, is_closed01)
+as_open01 = _cast_factory(float, is_open01, cast_name="float within (0, 1)")
+as_closed01 = _cast_factory(float, is_closed01, cast_name="float within [0, 1]")
 as_path = _cast_factory(Path)
-as_path_file = _cast_factory(Path, is_file)
-as_path_dir = _cast_factory(Path, is_dir)
-as_file = _cast_factory(str, is_file)
-as_dir = _cast_factory(str, is_dir)
+as_path_file = _cast_factory(Path, is_file, cast_name="readable file")
+as_path_dir = _cast_factory(Path, is_dir, cast_name="readable directory")
+as_file = _cast_factory(str, is_file, cast_name="readable file")
+as_dir = _cast_factory(str, is_dir, cast_name="readable directory")

--- a/src/pydrobert/torch/argcheck.py
+++ b/src/pydrobert/torch/argcheck.py
@@ -18,32 +18,25 @@ import os
 import string
 
 from typing import (
+    Collection,
     Optional,
     TypeVar,
     Callable,
     Any,
-    Collection,
     Type,
-    List,
-    TYPE_CHECKING,
+    Union,
 )
+from typing_extensions import overload, Literal, get_args
 from pathlib import Path
 
 import torch
 
-from ._compat import _v, script as _script
-
-if _v < "1.10.0":
-    script = torch.jit.ignore(drop=True)
-else:
-    script = _script
-
 V = TypeVar("V")
-NumLike = TypeVar("NumLike", float, int, torch.Tensor)
+NumLike = Union[torch.Tensor, float, int]
+N = TypeVar("N", *get_args(NumLike))
 StrPathLike = TypeVar("StrPathLike", str, os.PathLike, Path)
 
 
-@script
 def _nv(name: Optional[str], val: Any) -> str:
     if isinstance(val, torch.Tensor):
         if val.numel() == 1:
@@ -56,153 +49,75 @@ def _nv(name: Optional[str], val: Any) -> str:
         return f"{val}" if name is None else f"{name} ({val})"
 
 
-def _is_check_factory(t: Type[V], *ts: type):
+def _type_check_factory(t: Type[V], *ts: type):
     ts = (t,) + ts
-    suf = "n" if t.__name__.startswith(("a", "e", "i", "o", "u")) else ""
 
+    @overload
     def _is_check(
-        val: t, name: Optional[str] = None, _type_name: str = t.__name__
+        val: t, name: Optional[str] = None, allow_none: Literal[False] = False
     ) -> t:
-        if torch.jit.is_scripting():
-            return val
-        elif isinstance(val, ts):
-            return val if isinstance(val, t) else t(val)
+        ...
+
+    @overload
+    def _is_check(
+        val: Optional[t], name: Optional[str] = None, allow_none: Literal[True] = False
+    ) -> Optional[t]:
+        ...
+
+    def _is_check(val, name=None, allow_none=False):
+        if allow_none and val is None:
+            return None
+        if isinstance(val, _is_check.ts):
+            return val if isinstance(val, _is_check.t) else _is_check.t(val)
         else:
-            raise ValueError(f"{_nv(name, val)} is not a{suf} {_type_name}")
+            tname = _is_check.t.__name__
+            x = "n" if tname.startswith(("a", "e", "i", "o", "u")) else ""
+            y = " or None" if allow_none else ""
+            raise ValueError(f"{_nv(name, val)} is not a{x} {tname}{y}")
+
+    _is_check.t, _is_check.ts = t, ts
 
     return _is_check
 
 
-is_str = script(_is_check_factory(str))
-is_int = script(_is_check_factory(int))
-is_bool = script(_is_check_factory(bool, int, float))
-is_float = script(_is_check_factory(float, int))
-is_tensor = script(_is_check_factory(torch.Tensor))
-is_pathlike = torch.jit.unused(_is_check_factory(os.PathLike))
-is_path = torch.jit.unused(_is_check_factory(Path))
+is_str = _type_check_factory(str)
+is_int = _type_check_factory(int)
+is_bool = _type_check_factory(bool, int, float)
+is_float = _type_check_factory(float, int)
+is_tensor = _type_check_factory(torch.Tensor)
+is_pathlike = _type_check_factory(os.PathLike)
+is_path = _type_check_factory(Path)
 
 
-def _is_numcheck_factory(t: Type[NumLike], *ts: Type[NumLike]):
-    ts = (t,) + ts
-
-    def _is_poscheck(
-        val: t, name: Optional[str] = None, _type_name: str = t.__name__
-    ) -> t:
-        if not torch.jit.is_scripting():
-            if isinstance(val, ts):
-                val = t(val)
-            else:
-                raise ValueError(f"{_nv(name, val)} is not a positive {_type_name}")
-        if val <= 0:
-            raise ValueError(f"{_nv(name, val)} is not a positive {_type_name}")
-        return val
-
-    def _is_negcheck(
-        val: t, name: Optional[str] = None, _type_name: str = t.__name__
-    ) -> t:
-        if not torch.jit.is_scripting():
-            if isinstance(val, ts):
-                val = t(val)
-            else:
-                raise ValueError(f"{_nv(name, val)} is not a negative {_type_name}")
-        if val >= 0:
-            raise ValueError(f"{_nv(name, val)} is not a negative {_type_name}")
-        return val
-
-    def _is_nonposcheck(
-        val: t, name: Optional[str] = None, _type_name: str = t.__name__
-    ) -> t:
-        if not torch.jit.is_scripting():
-            if isinstance(val, ts):
-                val = t(val)
-            else:
-                raise ValueError(f"{_nv(name, val)} is not a non-positive {_type_name}")
-        if val > 0:
-            raise ValueError(f"{_nv(name, val)} is not a non-positive {_type_name}")
-        return val
-
-    def _is_nonnegcheck(
-        val: t, name: Optional[str] = None, _type_name: str = t.__name__
-    ) -> t:
-        if not torch.jit.is_scripting():
-            if isinstance(val, ts):
-                val = t(val)
-            else:
-                raise ValueError(f"{_nv(name, val)} is not a non-negative {_type_name}")
-        if val < 0:
-            raise ValueError(f"{_nv(name, val)} is not a non-negative {_type_name}")
-        return val
-
-    return _is_poscheck, _is_negcheck, _is_nonposcheck, _is_nonnegcheck
+@overload
+def is_numlike(
+    val: N, name: Optional[str] = None, allow_none: Literal[False] = False
+) -> N:
+    ...
 
 
-is_posi, is_negi, is_nonposi, is_nonnegi = _is_numcheck_factory(int)
-is_posi, is_negi = script(is_posi), script(is_negi)
-is_nonposi, is_nonnegi, is_nat = script(is_nonposi), script(is_nonnegi), is_posi
-is_posf, is_negf, is_nonposf, is_nonnegf = _is_numcheck_factory(float, int)
-is_posf, is_negf = script(is_posf), script(is_negf)
-is_nonposf, is_nonnegf = script(is_nonposf), script(is_nonnegf)
+@overload
+def is_numlike(
+    val: Optional[N], name: Optional[str] = None, allow_none: Literal[True] = False,
+) -> Optional[N]:
+    ...
 
 
-@script
-def is_post(val: torch.Tensor, name: Optional[str] = None) -> torch.Tensor:
-    if not torch.jit.is_scripting():
-        if not isinstance(val, torch.Tensor):
-            raise ValueError(
-                f"{_nv(name, val)} is not a tensor of only positive values"
-            )
-    if (val <= 0).any():
-        raise ValueError(f"{_nv(name, val)} is not a tensor of only positive values")
+def is_numlike(val, name=None, allow_none=False):
+    if allow_none and val is None:
+        return None
+    if not isinstance(val, get_args(NumLike)):
+        raise ValueError(f"{_nv(name, val)} is not num-like {get_args(N)}")
     return val
 
 
-@script
-def is_negt(val: torch.Tensor, name: Optional[str] = None) -> torch.Tensor:
-    if not torch.jit.is_scripting():
-        if not isinstance(val, torch.Tensor):
-            raise ValueError(
-                f"{_nv(name, val)} is not a tensor of only negative values"
-            )
-    if (val >= 0).any():
-        raise ValueError(f"{_nv(name, val)} is not a tensor of only negative values")
-    return val
-
-
-@script
-def is_nonpost(val: torch.Tensor, name: Optional[str] = None) -> torch.Tensor:
-    if not torch.jit.is_scripting():
-        if not isinstance(val, torch.Tensor):
-            raise ValueError(
-                f"{_nv(name, val)} is not a tensor of only non-positive values"
-            )
-    if (val > 0).any():
-        raise ValueError(
-            f"{_nv(name, val)} is not a tensor of only non-positive values"
-        )
-    return val
-
-
-@script
-def is_nonnegt(val: torch.Tensor, name: Optional[str] = None) -> torch.Tensor:
-    if not torch.jit.is_scripting():
-        if not isinstance(val, torch.Tensor):
-            raise ValueError(
-                f"{_nv(name, val)} is not a tensor of only non-negative values"
-            )
-    if (val < 0).any():
-        raise ValueError(
-            f"{_nv(name, val)} is not a tensor of only non-negative values"
-        )
-    return val
-
-
-@script
 def is_token(
     val: str,
     name: Optional[str] = None,
     empty_okay: bool = False,
     whitespace: str = string.whitespace,
 ) -> str:
+    val = is_str(val, name)
     if not empty_okay and not len(val):
         raise ValueError(f"{_nv(name, val)} is empty")
     else:
@@ -212,83 +127,325 @@ def is_token(
     return val
 
 
-@torch.jit.unused
-def is_a(val: V, t: Type[V], name: Optional[str] = None) -> V:
+@overload
+def is_a(
+    val: V, t: Type[V], name: Optional[str] = None, allow_none: Literal[False] = False
+) -> V:
+    ...
+
+
+@overload
+def is_a(
+    val: Optional[V],
+    t: Type[V],
+    name: Optional[str] = None,
+    allow_none: Literal[True] = False,
+) -> Optional[V]:
+    ...
+
+
+def is_a(val, t, name=None, allow_none=False):
+    if allow_none and val is None:
+        return None
     if not isinstance(val, t):
         suf = "n" if t.__name__.startswith(("a", "e", "i", "o", "u")) else ""
         raise ValueError(f"{_nv(name, val)} is not a{suf} {t.__name__}")
     return val
 
 
-if TYPE_CHECKING:
+@overload
+def is_in(
+    val: V,
+    collection: Collection[V],
+    name: Optional[str] = None,
+    allow_none: Literal[False] = False,
+) -> V:
+    ...
 
-    def is_numlike(val: NumLike, name: Optional[str] = None) -> NumLike:
-        ...
 
-    def is_pos(val: NumLike, name: Optional[str] = None) -> NumLike:
-        ...
+@overload
+def is_in(
+    val: Optional[V],
+    collection: Collection[V],
+    name: Optional[str] = None,
+    allow_none: Literal[True] = False,
+) -> Optional[V]:
+    ...
 
-    def is_neg(val: NumLike, name: Optional[str] = None) -> NumLike:
-        ...
 
-    def is_nonpos(val: NumLike, name: Optional[str] = None) -> NumLike:
-        ...
+def is_in(val, collection, name=None, allow_none=False):
+    if allow_none and val is None:
+        return None
+    if val not in collection:
+        raise ValueError(f"{_nv(name, val)} is not one of {collection}")
+    return val
 
-    def is_nonneg(val: NumLike, name: Optional[str] = None) -> NumLike:
-        ...
 
-    def is_equal(
-        val: NumLike,
+def is_pos(val: N, name: Optional[str] = None) -> N:
+    val_ = torch.as_tensor(is_numlike(val, name))
+    if (val_ <= 0).any():
+        x = "entirely " if val_.numel() > 1 else ""
+        raise ValueError(f"{_nv(name, val)} is not {x}positive")
+    return val
+
+
+def is_neg(val: N, name: Optional[str] = None) -> N:
+    val_ = torch.as_tensor(is_numlike(val, name))
+    if (val_ >= 0).any():
+        x = "entirely " if val_.numel() > 1 else ""
+        raise ValueError(f"{_nv(name, val)} is not {x}negative")
+    return val
+
+
+def is_nonpos(val: N, name: Optional[str] = None) -> N:
+    val_ = torch.as_tensor(is_numlike(val, name))
+    if (val_ > 0).any():
+        x = "entirely " if val_.numel() > 1 else ""
+        raise ValueError(f"{_nv(name, val)} is not {x}non-positive")
+    return val
+
+
+def is_nonneg(val: N, name: Optional[str] = None) -> N:
+    val_ = torch.as_tensor(is_numlike(val, name))
+    if (val_ < 0).any():
+        x = "entirely " if val_.numel() > 1 else ""
+        raise ValueError(f"{_nv(name, val)} is not {x}non-negative")
+    return val
+
+
+def is_exactly(
+    val: V, other: V, name: Optional[str] = None, other_name: Optional[str] = None
+) -> V:
+    if val is not other:
+        raise ValueError(f"{_nv(name, val)} is not {_nv(other_name, other)}")
+    return val
+
+
+def is_equal(
+    val: N, other: NumLike, name: Optional[str] = None, other_name: Optional[str] = None
+) -> V:
+    val_ = torch.as_tensor(is_numlike(val, name))
+    other_ = torch.as_tensor(is_numlike(other, other_name), device=val_.device)
+    if (val_ != other_).any():
+        x = "entirely " if val_.numel() > 1 else ""
+        raise ValueError(
+            f"{_nv(name, val)} is not {x}equal to {_nv(other_name, other)}"
+        )
+    return val
+
+
+def is_lt(
+    val: N,
+    other: Union[float, int, torch.Tensor],
+    name: Optional[str] = None,
+    other_name: Optional[str] = None,
+) -> N:
+    val_ = torch.as_tensor(is_numlike(val, name))
+    other_ = torch.as_tensor(is_numlike(other, other_name), device=val_.device)
+    if (val_ >= other_).any():
+        x = "entirely " if val_.numel() > 1 else ""
+        raise ValueError(
+            f"{_nv(name, val)} is not {x}less than {_nv(other_name, other)}"
+        )
+    return val
+
+
+def is_gt(
+    val: N,
+    other: Union[float, int, torch.Tensor],
+    name: Optional[str] = None,
+    other_name: Optional[str] = None,
+) -> N:
+    val_ = torch.as_tensor(is_numlike(val, name))
+    other_ = torch.as_tensor(is_numlike(other, other_name), device=val_.device)
+    if (val_ <= other_).any():
+        x = "entirely " if val_.numel() > 1 else ""
+        raise ValueError(
+            f"{_nv(name, val)} is not {x}greater than {_nv(other_name, other)}"
+        )
+    return val
+
+
+def is_lte(
+    val: N,
+    other: Union[float, int, torch.Tensor],
+    name: Optional[str] = None,
+    other_name: Optional[str] = None,
+) -> N:
+    val_ = torch.as_tensor(is_numlike(val, name))
+    other_ = torch.as_tensor(is_numlike(other, other_name), device=val_.device)
+    if (val_ > other_).any():
+        x = "entirely " if val_.numel() > 1 else ""
+        raise ValueError(
+            f"{_nv(name, val)} is not {x}less than or equal to "
+            f"{_nv(other_name, other)}"
+        )
+    return val
+
+
+def is_gte(
+    val: N,
+    other: Union[float, int, torch.Tensor],
+    name: Optional[str] = None,
+    other_name: Optional[str] = None,
+) -> N:
+    val_ = torch.as_tensor(is_numlike(val, name))
+    other_ = torch.as_tensor(is_numlike(other, other_name), device=val_.device)
+    if (val_ < other_).any():
+        x = "entirely " if val_.numel() > 1 else ""
+        raise ValueError(
+            f"{_nv(name, val)} is not {x}greater than or equal to"
+            f"{_nv(other_name, other)}"
+        )
+    return val
+
+
+def is_btw(
+    val: N,
+    left: NumLike,
+    right: NumLike,
+    name: Optional[str] = None,
+    left_name: Optional[str] = None,
+    right_name: Optional[str] = None,
+    left_inclusive: bool = False,
+    right_inclusive: bool = False,
+) -> N:
+    val_ = torch.as_tensor(is_numlike(val, name))
+    try:
+        if left_inclusive:
+            val_ = is_gte(val_, left, name, left_name)
+        else:
+            val_ = is_gt(val_, left, name, left_name)
+        if right_inclusive:
+            val_ = is_lte(val_, right, name, right_name)
+        else:
+            val_ = is_lt(val_, right, name, right_name)
+    except ValueError:
+        x = "entirely " if val_.numel() > 1 else ""
+        y = "incl." if left_inclusive else "excl."
+        z = "incl." if right_inclusive else "excl."
+        raise ValueError(
+            f"{_nv(name, val)} is not {x}within {_nv(left_name, left)} {y} and "
+            f"{_nv(right_name, right)} {z}"
+        )
+    return val
+
+
+def is_btw_open(
+    val: N,
+    left: NumLike,
+    right: NumLike,
+    name: Optional[str] = None,
+    left_name: Optional[str] = None,
+    right_name: Optional[str] = None,
+) -> N:
+    return is_btw(val, left, right, name, left_name, right_name, False, False)
+
+
+def is_btw_closed(
+    val: N,
+    left: NumLike,
+    right: NumLike,
+    name: Optional[str] = None,
+    left_name: Optional[str] = None,
+    right_name: Optional[str] = None,
+) -> N:
+    return is_btw(val, left, right, name, left_name, right_name, True, True)
+
+
+def is_open01(val: N, name: Optional[str] = None) -> N:
+    return is_btw(val, 0, 1, name, None, None, False, False)
+
+
+def is_closed01(val: N, name: Optional[str] = None) -> N:
+    return is_btw(val, 0, 1, name, None, None, True, True)
+
+
+def _numlike_special_factory(t: Type[N], *ts: Type[N]):
+
+    _type_check = _type_check_factory(t, *ts)
+
+    def _pos_check(val: t, name: Optional[str] = None) -> t:
+        val = _pos_check.type_check(val, name)
+        return is_pos(val, name)
+
+    _pos_check.type_check = _type_check
+
+    def _neg_check(val: t, name: Optional[str] = None) -> t:
+        val = _neg_check.type_check(val, name)
+        return is_neg(val, name)
+
+    _neg_check.type_check = _type_check
+
+    def _nonpos_check(val: t, name: Optional[str] = None) -> t:
+        val = _nonpos_check.type_check(val, name)
+        return is_nonpos(val, name)
+
+    _nonpos_check.type_check = _type_check
+
+    def _nonneg_check(val: t, name: Optional[str] = None) -> t:
+        val = _nonneg_check.type_check(val, name)
+        return is_nonneg(val, name)
+
+    _nonneg_check.type_check = _type_check
+
+    def _equal_check(
+        val: t,
         other: NumLike,
         name: Optional[str] = None,
         other_name: Optional[str] = None,
-    ) -> NumLike:
-        ...
+    ) -> t:
+        val = _equal_check.type_check(val, name)
+        return is_equal(val, other, name, other_name)
 
-    def is_exactly(
-        val: V,
-        other: Any,
-        name: Optional[str] = None,
-        other_name: Optional[str] = None,
-    ) -> V:
-        ...
+    _equal_check.type_check = _type_check
 
-    def is_lt(
-        val: NumLike,
+    def _lt_check(
+        val: t,
         other: NumLike,
         name: Optional[str] = None,
         other_name: Optional[str] = None,
-        inclusive: bool = False,
-    ) -> NumLike:
-        ...
+    ) -> t:
+        val = _lt_check.type_check(val, name)
+        return is_lt(val, other, name, other_name)
 
-    def is_lte(
-        val: NumLike,
+    _lt_check.type_check = _type_check
+
+    def _lte_check(
+        val: t,
         other: NumLike,
         name: Optional[str] = None,
         other_name: Optional[str] = None,
-    ) -> NumLike:
-        ...
+    ) -> t:
+        val = _lte_check.type_check(val, name)
+        return is_lte(val, other, name, other_name)
 
-    def is_gt(
-        val: NumLike,
+    _lte_check.type_check = _type_check
+
+    def _gt_check(
+        val: t,
         other: NumLike,
         name: Optional[str] = None,
         other_name: Optional[str] = None,
-        inclusive: bool = False,
-    ) -> NumLike:
-        ...
+    ) -> t:
+        val = _gt_check.type_check(val, name)
+        return is_gt(val, other, name, other_name)
 
-    def is_gte(
-        val: NumLike,
+    _gt_check.type_check = _type_check
+
+    def _gte_check(
+        val: t,
         other: NumLike,
         name: Optional[str] = None,
         other_name: Optional[str] = None,
-    ) -> NumLike:
-        ...
+    ) -> t:
+        val = _gte_check.type_check(val, name)
+        return is_gte(val, other, name, other_name)
 
-    def is_btw(
-        val: NumLike,
+    _gte_check.type_check = _type_check
+
+    def _btw_check(
+        val: t,
         left: NumLike,
         right: NumLike,
         name: Optional[str] = None,
@@ -296,262 +453,141 @@ if TYPE_CHECKING:
         right_name: Optional[str] = None,
         left_inclusive: bool = False,
         right_inclusive: bool = False,
-    ) -> NumLike:
-        ...
+    ) -> t:
+        val = _btw_check.type_check(val, name)
+        return is_btw(
+            val,
+            left,
+            right,
+            name,
+            left_name,
+            right_name,
+            left_inclusive,
+            right_inclusive,
+        )
 
-    def is_in(val: V, choices: Collection[Any], name: Optional[str] = None) -> V:
-        ...
+    _btw_check.type_check = _type_check
 
-    def is_open01(val: NumLike, name: Optional[str] = None) -> NumLike:
-        ...
-
-    def is_closed01(val: NumLike, name: Optional[str] = None) -> NumLike:
-        ...
-
-
-else:
-
-    @script
-    def is_numlike(val: Any, name: Optional[str] = None) -> Any:
-        if (
-            not isinstance(val, int)
-            and not isinstance(val, float)
-            and not isinstance(val, torch.Tensor)
-        ):
-            raise ValueError(
-                f"{_nv(name, val)} is not number-like (float, int, or Tensor)"
-            )
-        return val
-
-    @script
-    def is_pos(val: Any, name: Optional[str] = None) -> Any:
-        okay: Optional[bool] = None
-        if isinstance(val, torch.Tensor):
-            okay = bool((val > 0).all().item())
-        if isinstance(val, (float, int)):
-            okay = val > 0
-        if okay is None:
-            raise ValueError(f"{_nv(name, val)} is not num-like")
-        if not okay:
-            raise ValueError(f"{_nv(name, val)} is not positive")
-        return val
-
-    @script
-    def is_neg(val: Any, name: Optional[str] = None) -> Any:
-        okay: Optional[bool] = None
-        if isinstance(val, torch.Tensor):
-            okay = bool((val < 0).all().item())
-        if isinstance(val, (float, int)):
-            okay = val < 0
-        if okay is None:
-            raise ValueError(f"{_nv(name, val)} is not num-like")
-        if not okay:
-            raise ValueError(f"{_nv(name, val)} is not negative")
-        return val
-
-    @script
-    def is_nonpos(val: Any, name: Optional[str] = None) -> Any:
-        okay: Optional[bool] = None
-        if isinstance(val, torch.Tensor):
-            okay = bool((val <= 0).all().item())
-        if isinstance(val, (float, int)):
-            okay = val <= 0
-        if okay is None:
-            raise ValueError(f"{_nv(name, val)} is not num-like")
-        if not okay:
-            raise ValueError(f"{_nv(name, val)} is positive")
-        return val
-
-    @script
-    def is_nonneg(val: Any, name: Optional[str] = None) -> Any:
-        okay: Optional[bool] = None
-        if isinstance(val, torch.Tensor):
-            okay = bool((val >= 0).all().item())
-        if isinstance(val, (float, int)):
-            okay = val >= 0
-        if okay is None:
-            raise ValueError(f"{_nv(name, val)} is not num-like")
-        if not okay:
-            raise ValueError(f"{_nv(name, val)} is not negative")
-        return val
-
-    @script
-    def is_equal(
-        val: Any,
-        other: Any,
-        name: Optional[str] = None,
-        other_name: Optional[str] = None,
-    ) -> Any:
-        okay: Optional[bool] = None
-        if isinstance(val, torch.Tensor) and isinstance(other, torch.Tensor):
-            okay = bool((val == other).all().item())
-        if isinstance(val, torch.Tensor) and isinstance(other, (int, float)):
-            okay = bool((val == other).all().item())
-        if isinstance(other, torch.Tensor) and isinstance(val, (int, float)):
-            okay = bool((other == val).all().item())
-        if isinstance(val, (float, int)) and isinstance(other, (float, int)):
-            okay = float(val) == float(other)
-        if okay is None:
-            raise ValueError(f"{_nv(name, val)} is not num-like")
-        elif not okay:
-            raise ValueError(
-                f"{_nv(name, val)} does not equal {_nv(other_name, other)}"
-            )
-        return val
-
-    @script
-    def is_exactly(
-        val: Any,
-        other: Any,
-        name: Optional[str] = None,
-        other_name: Optional[str] = None,
-    ) -> Any:
-        if val is not other:
-            raise ValueError(f"{_nv(name, val)} is not {_nv(other_name, other)}")
-        return val
-
-    @script
-    def is_lt(
-        val: Any,
-        other: Any,
-        name: Optional[str] = None,
-        other_name: Optional[str] = None,
-        inclusive: bool = False,
-    ) -> Any:
-        okay: Optional[bool] = None
-        comp = ">"
-        if inclusive:
-            if isinstance(val, torch.Tensor) and isinstance(other, torch.Tensor):
-                okay = bool((val <= other).all().item())
-            if isinstance(val, torch.Tensor) and isinstance(other, (float, int)):
-                okay = bool((val <= other).all().item())
-            if isinstance(other, torch.Tensor) and isinstance(val, (float, int)):
-                okay = bool((other >= val).all().item())
-            if isinstance(val, (float, int)) and isinstance(other, (float, int)):
-                okay = float(val) <= float(other)
-        else:
-            comp = ">="
-            if isinstance(val, torch.Tensor) and isinstance(other, torch.Tensor):
-                okay = bool((val < other).all().item())
-            if isinstance(val, torch.Tensor) and isinstance(other, (float, int)):
-                okay = bool((val < other).all().item())
-            if isinstance(other, torch.Tensor) and isinstance(val, (float, int)):
-                okay = bool((other > val).all().item())
-            if isinstance(val, (float, int)) and isinstance(other, (float, int)):
-                okay = float(val) < float(other)
-        if okay is None:
-            raise ValueError(
-                f"{_nv(name, val)} or {_nv(other_name, other)} is not num-like"
-            )
-        if not okay:
-            raise ValueError(f"{_nv(name, val)} {comp} {_nv(other_name, other)}")
-        return val
-
-    def is_lte(
-        val: Any,
-        other: Any,
-        name: Optional[str] = None,
-        other_name: Optional[str] = None,
-    ) -> Any:
-        return is_lt(val, other, name, other_name, True)
-
-    @script
-    def is_gt(
-        val: Any,
-        other: Any,
-        name: Optional[str] = None,
-        other_name: Optional[str] = None,
-        inclusive: bool = False,
-    ) -> Any:
-        okay: Optional[bool] = None
-        comp = "<"
-        if inclusive:
-            if isinstance(val, torch.Tensor) and isinstance(other, torch.Tensor):
-                okay = bool((val >= other).all().item())
-            if isinstance(val, torch.Tensor) and isinstance(other, (float, int)):
-                okay = bool((val >= other).all().item())
-            if isinstance(other, torch.Tensor) and isinstance(val, (float, int)):
-                okay = bool((other <= val).all().item())
-            if isinstance(val, (float, int)) and isinstance(other, (float, int)):
-                okay = float(val) >= float(other)
-        else:
-            comp = "<="
-            if isinstance(val, torch.Tensor) and isinstance(other, torch.Tensor):
-                okay = bool((val > other).all().item())
-            if isinstance(val, torch.Tensor) and isinstance(other, (float, int)):
-                okay = bool((val > other).all().item())
-            if isinstance(other, torch.Tensor) and isinstance(val, (float, int)):
-                okay = bool((other < val).all().item())
-            if isinstance(val, (float, int)) and isinstance(other, (float, int)):
-                okay = float(val) > float(other)
-        if okay is None:
-            raise ValueError(
-                f"{_nv(name, val)} or {_nv(other_name, other)} is not num-like"
-            )
-        if not okay:
-            raise ValueError(f"{_nv(name, val)} {comp} {_nv(other_name, other)}")
-        return val
-
-    def is_gte(
-        val: Any,
-        other: Any,
-        name: Optional[str] = None,
-        other_name: Optional[str] = None,
-    ) -> Any:
-        return is_gt(val, other, name, other_name, True)
-
-    def is_btw(
-        val: Any,
-        left: Any,
-        right: Any,
+    def _btw_open_check(
+        val: t,
+        left: NumLike,
+        right: NumLike,
         name: Optional[str] = None,
         left_name: Optional[str] = None,
         right_name: Optional[str] = None,
-        left_inclusive: bool = False,
-        right_inclusive: bool = False,
-    ) -> Any:
-        is_lt(val, right, name, right_name, right_inclusive)
-        is_gt(val, left, name, left_name, left_inclusive)
-        return val
+    ) -> t:
+        val = _btw_open_check.type_check(val, name)
+        return is_btw_open(val, left, right, name, left_name, right_name, False, False)
 
-    @script
-    def is_in(val: Any, choices: List[Any], name: Optional[str] = None) -> Any:
-        okay: bool = False
-        if torch.jit.is_scripting():
-            for choice in choices:
-                if val is choice:
-                    okay = True
-        else:
-            okay = val in choices
-        if not okay:
-            raise ValueError(f"{_nv(name, val)} not in {list(choices)}")
-        return val
+    _btw_open_check.type_check = _type_check
 
-    @script
-    def is_open01(val: Any, name: Optional[str] = None) -> Any:
-        return is_btw(val, 0.0, 1.0, name)
+    def _btw_closed_check(
+        val: t,
+        left: NumLike,
+        right: NumLike,
+        name: Optional[str] = None,
+        left_name: Optional[str] = None,
+        right_name: Optional[str] = None,
+    ) -> t:
+        val = _btw_closed_check.type_check(val, name)
+        return is_btw_closed(val, left, right, name, left_name, right_name, True, True)
 
-    @script
-    def is_closed01(val: Any, name: Optional[str] = None) -> Any:
-        return is_btw(val, 0.0, 1.0, name, left_inclusive=True, right_inclusive=True)
+    _btw_closed_check.type_check = _type_check
+
+    def _open01_check(val: t, name: Optional[str] = None) -> t:
+        val = _open01_check.type_check(val, name)
+        return is_open01(val, name)
+
+    _open01_check.type_check = _type_check
+
+    def _closed01_check(val: t, name: Optional[str] = None) -> t:
+        val = _closed01_check.type_check(val, name)
+        return is_nonneg(val, name)
+
+    _closed01_check.type_check = _type_check
+
+    return (
+        _pos_check,
+        _neg_check,
+        _nonpos_check,
+        _nonneg_check,
+        _equal_check,
+        _lt_check,
+        _lte_check,
+        _gt_check,
+        _gte_check,
+        _btw_check,
+        _btw_open_check,
+        _btw_closed_check,
+        _open01_check,
+        _closed01_check,
+    )
 
 
-@torch.jit.unused
+(
+    is_posi,
+    is_negi,
+    is_nonposi,
+    is_nonnegi,
+    is_equali,
+    is_lti,
+    is_ltei,
+    is_gti,
+    is_gtei,
+    is_btwi,
+    is_btw_openi,
+    is_btw_closedi,
+    is_open01i,
+    is_closed01i,
+) = _numlike_special_factory(int)
+is_nat = is_posi
+(
+    is_posf,
+    is_negf,
+    is_nonposf,
+    is_nonnegf,
+    is_equalf,
+    is_ltf,
+    is_ltef,
+    is_gtf,
+    is_gtef,
+    is_btwf,
+    is_btw_openf,
+    is_btw_closedf,
+    is_open01f,
+    is_closed01f,
+) = _numlike_special_factory(float, int)
+(
+    is_post,
+    is_negt,
+    is_nonpost,
+    is_nonnegt,
+    is_equalt,
+    is_ltt,
+    is_ltet,
+    is_gtt,
+    is_gtet,
+    is_btwt,
+    is_btw_opent,
+    is_btw_closedt,
+    is_open01t,
+    is_closed01t,
+) = _numlike_special_factory(torch.Tensor)
+
+
 def is_file(val: StrPathLike, name: Optional[str] = None) -> StrPathLike:
     if not os.path.isfile(val):
         raise ValueError(f"{_nv(name, val)} is not a file")
     return val
 
 
-@torch.jit.unused
 def is_dir(val: StrPathLike, name: Optional[str] = None) -> StrPathLike:
     if not os.path.isdir(val):
         raise ValueError(f"{_nv(name, val)} is not a directory")
     return val
 
 
-@script
-def has_ndim(val: torch.Tensor, ndim: int, name: str = "tensor") -> torch.Tensor:
+def has_ndim(val: torch.Tensor, ndim: int, name: Optional[str] = None) -> torch.Tensor:
     if val.ndim != ndim:
         raise ValueError(
             f"Expected {_nv(name, val)} to have dimension {ndim}; got {val.ndim}"
@@ -559,10 +595,9 @@ def has_ndim(val: torch.Tensor, ndim: int, name: str = "tensor") -> torch.Tensor
     return val
 
 
-@script
-def is_nonempty(val: torch.Tensor, name: str = "tensor") -> torch.Tensor:
+def is_nonempty(val: torch.Tensor, name: Optional[str] = None) -> torch.Tensor:
     if not val.numel():
-        raise ValueError(f"Expected {name} to be nonempty")
+        raise ValueError(f"Expected {_nv(name, val)} to be nonempty")
     return val
 
 
@@ -571,7 +606,6 @@ def _cast_factory(
     check: Optional[Callable[[V, Optional[str]], V]] = None,
     cast_name: Optional[str] = None,
 ):
-    @torch.jit.unused
     def _cast(val: Any, name: Optional[str] = None) -> V:
         try:
             val = cast(val)

--- a/src/pydrobert/torch/argcheck.py
+++ b/src/pydrobert/torch/argcheck.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Boilerplate for checking argument values"""
+"""Boilerplate for checking argument values
+
+These functions are intended for use primarily in :class:`torch.Module` definitions
+and are not :mod:`torch.jit` safe.
+"""
 
 import os
 import string
@@ -145,6 +149,7 @@ def is_a(
 
 
 def is_a(val, t, name=None, allow_none=False):
+    assert not issubclass(t, torch.nn.Module), f"what if {t} is scripted?"
     if allow_none and val is None:
         return None
     if not isinstance(val, t):
@@ -181,6 +186,14 @@ def is_in(val, collection, name=None, allow_none=False):
     return val
 
 
+def is_exactly(
+    val: V, other: V, name: Optional[str] = None, other_name: Optional[str] = None
+) -> V:
+    if val is not other:
+        raise ValueError(f"{_nv(name, val)} is not {_nv(other_name, other)}")
+    return val
+
+
 def is_pos(val: N, name: Optional[str] = None) -> N:
     val_ = torch.as_tensor(is_numlike(val, name))
     if (val_ <= 0).any():
@@ -210,14 +223,6 @@ def is_nonneg(val: N, name: Optional[str] = None) -> N:
     if (val_ < 0).any():
         x = "entirely " if val_.numel() > 1 else ""
         raise ValueError(f"{_nv(name, val)} is not {x}non-negative")
-    return val
-
-
-def is_exactly(
-    val: V, other: V, name: Optional[str] = None, other_name: Optional[str] = None
-) -> V:
-    if val is not other:
-        raise ValueError(f"{_nv(name, val)} is not {_nv(other_name, other)}")
     return val
 
 

--- a/src/pydrobert/torch/command_line.py
+++ b/src/pydrobert/torch/command_line.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Sean Robertson
+# Copyright 2023 Sean Robertson
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/pydrobert/torch/command_line.py
+++ b/src/pydrobert/torch/command_line.py
@@ -72,6 +72,7 @@ _COMMON_ARGS = {
     },
     "--unk-symbol": {
         "default": None,
+        "type": argcheck.is_token,
         "help": "If set, will map out-of-vocabulary tokens to this symbol",
     },
     "--frame-shift-ms": {
@@ -815,6 +816,7 @@ SpectDataSet directory."""
     )
     utt_group.add_argument(
         "--channel",
+        type=argcheck.is_token,
         default=config.DEFT_CTM_CHANNEL,
         help='If neither "--wc2utt" nor "--utt2wc" is specified, utterance '
         "IDs are treated as wavefile names and are given the value of this "

--- a/src/pydrobert/torch/command_line.py
+++ b/src/pydrobert/torch/command_line.py
@@ -26,7 +26,7 @@ import shutil
 
 from pathlib import Path
 from collections import defaultdict, OrderedDict
-from typing import Dict, Optional, Sequence, Type, TypeVar
+from typing import Dict, Optional, Sequence
 from typing_extensions import Literal
 
 import torch

--- a/src/pydrobert/torch/command_line.py
+++ b/src/pydrobert/torch/command_line.py
@@ -26,54 +26,16 @@ import shutil
 
 from pathlib import Path
 from collections import defaultdict, OrderedDict
-from typing import Any, Callable, Dict, Optional, Sequence, Type, TypeVar
+from typing import Dict, Optional, Sequence, Type, TypeVar
 from typing_extensions import Literal
 
 import torch
 
-from . import data, modules, config
+from . import data, modules, config, argcheck
 from ._feats import SliceSpectData, ChunkTokenSequencesBySlices
 from ._pad import ChunkBySlices
 from ._string import error_rate
 from ._datasets import _info_and_validate
-
-
-def rdir(x: str) -> str:
-    if not os.path.isdir(x):
-        raise TypeError(f"'{x}' is not a directory")
-    return x
-
-
-R = TypeVar("R")
-
-
-def bounded(
-    x: str,
-    type: Type[R],
-    lower: Optional[R] = None,
-    upper: Optional[R] = None,
-    inclusive_lower: bool = True,
-    inclusive_upper: bool = True,
-) -> R:
-    x: R = type(x)
-    if lower is not None:
-        if inclusive_lower and x < lower:
-            raise TypeError(f"Expected {x} >= {lower}")
-        elif not inclusive_lower and x <= lower:
-            raise TypeError(f"Expected {x} > {lower}")
-    if upper is not None:
-        if inclusive_upper and x > upper:
-            raise TypeError(f"Expected {x} <= {upper}")
-        elif not inclusive_upper and x >= upper:
-            raise TypeError(f"Expected {x} < {upper}")
-    return x
-
-
-nat = lambda x: bounded(x, int, 1)
-nat0 = lambda x: bounded(x, int, 0)
-pos = lambda x: bounded(x, float, 0, inclusive_lower=False)
-open01 = lambda x: bounded(x, float, 0.0, 1.0, False, False)
-closed01 = lambda x: bounded(x, float, 0.0, 1.0)
 
 
 _COMMON_ARGS = {
@@ -98,7 +60,7 @@ _COMMON_ARGS = {
         'used to swap the expected ordering (i.e. to "<token> <id>")',
     },
     "--num-workers": {
-        "type": int,
+        "type": argcheck.as_nonnegi,
         "default": config.DEFT_NUM_WORKERS,
         "help": "The number of workers to spawn to process the data. 0 is serial. "
         "Defaults to the CPU count",
@@ -113,7 +75,7 @@ _COMMON_ARGS = {
         "help": "If set, will map out-of-vocabulary tokens to this symbol",
     },
     "--frame-shift-ms": {
-        "type": pos,
+        "type": argcheck.as_posf,
         "default": config.DEFT_FRAME_SHIFT_MS,
         "help": "The number of milliseconds that have passed between consecutive "
         "frames. Used to convert between time in seconds and frame index. If your "
@@ -134,7 +96,7 @@ _COMMON_ARGS = {
         "loaded as features in a SpectDataSet.",
     },
     "--mp-chunk-size": {
-        "type": nat,
+        "type": argcheck.as_nat,
         "default": config.DEFT_CHUNK_SIZE,
         "help": "The number of utterances that a multiprocessing worker will process "
         "at once. Impacts speed and memory consumption.",
@@ -238,7 +200,7 @@ integers."""
         description=get_torch_spect_data_dir_info.__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("dir", type=rdir, help="The torch data directory")
+    parser.add_argument("dir", type=argcheck.as_dir, help="The torch data directory")
     parser.add_argument(
         "out_file",
         nargs="?",
@@ -263,7 +225,7 @@ integers."""
         "--fix",
         nargs="?",
         metavar="N",
-        type=nat0,
+        type=argcheck.as_nonnegi,
         const=1,
         default=None,
         help="If set, validate the data directory before collecting info, potentially "
@@ -308,9 +270,7 @@ def _parse_token2id(file, swap, return_swap):
             continue
         ls = line.split()
         if len(ls) != 2 or not ls[1 - int(swap)].lstrip("-").isdigit():
-            raise ValueError(
-                "Cannot parse line {} of {}".format(line_no + 1, file.name)
-            )
+            raise ValueError(f"Cannot parse line {line_no + 1} of {file.name}")
         key, value = ls
         key, value = (int(key), value) if swap else (key, int(value))
         if key in ret:
@@ -409,7 +369,7 @@ with the "ref/" directory of a SpectDataSet. See the command
                 if isinstance(x, str):
                     transcript.append(x)
                 elif options.alt_handler == "error":
-                    raise ValueError('Cannot handle alternate in "{}"'.format(utt_id))
+                    raise ValueError(f"Cannot handle alternate in '{utt_id}'")
                 else:  # first
                     x[0].extend(old_transcript)
                     old_transcript = x[0]
@@ -476,8 +436,7 @@ class _TranscriptDataSet(_DirectoryDataset):
             if isinstance(token, int) and self.id2token is not None:
                 assert token not in self.id2token
                 raise ValueError(
-                    'Utterance "{}": ID "{}" could not be found in id2token'
-                    "".format(utt_id, token)
+                    f"Utterance '{utt_id}': ID '{token}' could not be found in id2token"
                 )
         return utt_id, transcript
 
@@ -525,7 +484,7 @@ info about a SpectDataSet directory."""
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "dir", type=rdir, help="The directory to read token sequences from"
+        "dir", type=argcheck.as_dir, help="The directory to read token sequences from"
     )
     _add_common_arg(parser, "id2token")
     parser.add_argument(
@@ -714,7 +673,9 @@ directory."""
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "tg_dir", type=rdir, help="The directory containing the TextGrid files"
+        "tg_dir",
+        type=argcheck.as_dir,
+        help="The directory containing the TextGrid files",
     )
     _add_common_arg(parser, "token2id")
     parser.add_argument(
@@ -823,7 +784,7 @@ SpectDataSet directory."""
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "dir", type=rdir, help="The directory to read token sequences from"
+        "dir", type=argcheck.as_dir, help="The directory to read token sequences from"
     )
     _add_common_arg(parser, "id2token")
     parser.add_argument(
@@ -914,7 +875,7 @@ performing these computations."""
     )
     parser.add_argument(
         "dir",
-        type=rdir,
+        type=argcheck.as_dir,
         help="If the 'hyp' argument is not specified, this is the "
         "parent directory of two subdirectories, 'ref/' and 'hyp/', which "
         "contain the reference and hypothesis transcripts, respectively. If "
@@ -924,7 +885,7 @@ performing these computations."""
     parser.add_argument(
         "hyp",
         nargs="?",
-        type=rdir,
+        type=argcheck.as_dir,
         default=None,
         help="The hypothesis transcript directory",
     )
@@ -987,7 +948,7 @@ performing these computations."""
     )
     parser.add_argument(
         "--batch-size",
-        type=nat,
+        type=argcheck.as_nat,
         default=100,
         help="The number of error rates to compute at once. Reduce if you "
         "run into memory errors",
@@ -1233,7 +1194,7 @@ This command does not require WebDataset to be installed."""
         description=torch_spect_data_dir_to_wds.__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("dir", type=rdir, help="The torch data directory")
+    parser.add_argument("dir", type=argcheck.as_dir, help="The torch data directory")
     parser.add_argument("tar_path", help="The path to store files to")
     _add_common_arg(parser, "--file-prefix")
     _add_common_arg(parser, "--file-suffix")
@@ -1249,14 +1210,14 @@ This command does not require WebDataset to be installed."""
     )
     parser.add_argument(
         "--max-samples-per-shard",
-        type=nat,
+        type=argcheck.as_nat,
         default=1e5,
         help="If sharding ('--shard' is specified), dictates the number of samples in "
         "each file.",
     )
     parser.add_argument(
         "--max-size-per-shard",
-        type=nat,
+        type=argcheck.as_nat,
         default=3e9,
         help="If sharding ('--shard' is specified), dictates the maximum size in bytes "
         "of each file.",
@@ -1291,10 +1252,6 @@ This command does not require WebDataset to be installed."""
     if options.shard:
         max_bytes = options.max_size_per_shard
         max_count = options.max_samples_per_shard
-        if max_bytes <= 0:
-            raise argparse.ArgumentTypeError("--max-size-per-shard must be positive")
-        if max_count <= 0:
-            raise argparse.ArgumentTypeError("--max-samples-per-shard must be positive")
         max_num_shards = (NN - 1) // max_count + 1
         max_shard = max(max_num_shards - 1, 1)
         pattern += f".{{shard:0{int(math.ceil(math.log(max_shard)))}d}}"
@@ -1368,7 +1325,7 @@ pickled, nested dictionary
 of the statistics of all groups.
 """,
     )
-    parser.add_argument("dir", type=rdir, help="The feature directory")
+    parser.add_argument("dir", type=argcheck.as_dir, help="The feature directory")
     parser.add_argument("out", help="Output path")
     _add_common_arg(parser, "--file-prefix")
     _add_common_arg(parser, "--file-suffix")
@@ -1510,7 +1467,9 @@ See the command "get-torch-spect-data-dir-info" for more info SpectDataSet direc
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "ref_dir", type=rdir, help="The token sequence data directory (input)",
+        "ref_dir",
+        type=argcheck.as_dir,
+        help="The token sequence data directory (input)",
     )
     parser.add_argument(
         "ali_dir", help="The frame alignment data directory (output)",
@@ -1578,7 +1537,9 @@ See the command "get-torch-spect-data-dir-info" for more info SpectDataSet direc
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "ali_dir", type=rdir, help="The frame alignment data directory (input)",
+        "ali_dir",
+        type=argcheck.as_dir,
+        help="The frame alignment data directory (input)",
     )
     parser.add_argument(
         "ref_dir", help="The token sequence data directory (output)",
@@ -1743,7 +1704,9 @@ directory."""
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "ref_dir", type=rdir, help="The token sequence data directory (input)"
+        "ref_dir",
+        type=argcheck.as_dir,
+        help="The token sequence data directory (input)",
     )
     _add_common_arg(parser, "id2token")
     parser.add_argument("tg_dir", help="The TextGrid directory (output)")
@@ -1767,7 +1730,7 @@ directory."""
     )
     parser.add_argument(
         "--precision",
-        type=nat0,
+        type=argcheck.as_nonnegi,
         default=config.DEFT_FLOAT_PRINT_PRECISION,
         help="Precision with which to save floating point values in TextGrid files",
     )
@@ -1914,7 +1877,7 @@ See the command "get-torch-spect-data-dir-info" for more info SpectDataSet direc
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "in_dir", type=rdir, help="The torch data directory to chunk (input)"
+        "in_dir", type=argcheck.as_dir, help="The torch data directory to chunk (input)"
     )
     parser.add_argument(
         "out_dir", help="The torch data directory to store chunks (output)"
@@ -1934,7 +1897,7 @@ See the command "get-torch-spect-data-dir-info" for more info SpectDataSet direc
     )
     parser.add_argument(
         "--lobe-size",
-        type=nat0,
+        type=argcheck.as_nonnegi,
         default=0,
         help="Size of a side lobe of a slice. See SliceSpectData.",
     )
@@ -2120,7 +2083,9 @@ This command has a similar functionality to Kaldi's (https://github.com/kaldi-as
 subset_data_dir.sh script, but defaults to hard links for cross-compatibility.
 """,
     )
-    parser.add_argument("src", type=rdir, help="The directory to extract from")
+    parser.add_argument(
+        "src", type=argcheck.as_dir, help="The directory to extract from"
+    )
     parser.add_argument("dest", help="The directory to extract to")
     style = parser.add_mutually_exclusive_group()
     style.add_argument(
@@ -2153,35 +2118,35 @@ subset_data_dir.sh script, but defaults to hard links for cross-compatibility.
     )
     criteria.add_argument(
         "--first-n",
-        type=nat0,
+        type=argcheck.as_nonnegi,
         metavar="N",
         default=None,
         help="Extract this number of utterances listed first by id",
     )
     criteria.add_argument(
         "--first-ratio",
-        type=closed01,
+        type=argcheck.as_closed01,
         metavar="R",
         default=None,
         help="Extract this ratio of utterances (rounding down) listed first by id",
     )
     criteria.add_argument(
         "--last-n",
-        type=nat0,
+        type=argcheck.as_nonnegi,
         metavar="N",
         default=None,
         help="Extract this number of utterances listed last by id",
     )
     criteria.add_argument(
         "--last-ratio",
-        type=closed01,
+        type=argcheck.as_closed01,
         metavar="R",
         default=None,
         help="Extract this ratio of utterances (rounding down) listed last by id",
     )
     criteria.add_argument(
         "--shortest-n",
-        type=nat0,
+        type=argcheck.as_nonnegi,
         metavar="N",
         default=None,
         help="Extract this number of utterances listed first by increasing length, "
@@ -2189,7 +2154,7 @@ subset_data_dir.sh script, but defaults to hard links for cross-compatibility.
     )
     criteria.add_argument(
         "--shortest-ratio",
-        type=closed01,
+        type=argcheck.as_closed01,
         metavar="R",
         default=None,
         help="Extract this ratio of utterances listed first by increasing length, "
@@ -2197,7 +2162,7 @@ subset_data_dir.sh script, but defaults to hard links for cross-compatibility.
     )
     criteria.add_argument(
         "--longest-n",
-        type=nat0,
+        type=argcheck.as_nonnegi,
         metavar="N",
         default=None,
         help="Extract this number of utterances listed first by decreasing length, "
@@ -2205,7 +2170,7 @@ subset_data_dir.sh script, but defaults to hard links for cross-compatibility.
     )
     criteria.add_argument(
         "--longest-ratio",
-        type=closed01,
+        type=argcheck.as_closed01,
         metavar="R",
         default=None,
         help="Extract this ratio of utterances listed first by decreasing length, "
@@ -2213,14 +2178,14 @@ subset_data_dir.sh script, but defaults to hard links for cross-compatibility.
     )
     criteria.add_argument(
         "--rand-n",
-        type=nat0,
+        type=argcheck.as_nonnegi,
         metavar="N",
         default=None,
         help="Extract this number of utterances listed randomly",
     )
     criteria.add_argument(
         "--rand-ratio",
-        type=closed01,
+        type=argcheck.as_closed01,
         metavar="R",
         default=None,
         help="Extract this ratio of utterances listed randomly",
@@ -2254,9 +2219,7 @@ subset_data_dir.sh script, but defaults to hard links for cross-compatibility.
         feat_dir = options.src
     else:
         feat_dir = os.path.join(options.src, options.feat_subdir)
-        if not os.path.isdir(feat_dir):
-            print(f"'{feat_dir}' does not exist", file=sys.stderr)
-            return 1
+        argcheck.is_dir(feat_dir, name="feat_dir")
         if not os.path.isdir(os.path.join(options.src, options.ali_subdir)):
             options.ali_subdir = None
         if not os.path.isdir(os.path.join(options.src, options.ref_subdir)):
@@ -2395,7 +2358,7 @@ directory."""
         description=print_torch_ali_data_dir_length_moments.__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("dir", type=rdir, help="The ali/ dir (input)")
+    parser.add_argument("dir", type=argcheck.as_dir, help="The ali/ dir (input)")
     parser.add_argument(
         "out",
         nargs="?",
@@ -2405,7 +2368,7 @@ directory."""
     )
     parser.add_argument(
         "--precision",
-        type=nat0,
+        type=argcheck.as_nonnegi,
         default=config.DEFT_FLOAT_PRINT_PRECISION,
         help="Precision with which to print stats",
     )
@@ -2502,7 +2465,7 @@ directory."""
         description=print_torch_ali_data_dir_length_moments.__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("dir", type=rdir, help="The ref/ dir (input)")
+    parser.add_argument("dir", type=argcheck.as_dir, help="The ref/ dir (input)")
     parser.add_argument(
         "out",
         nargs="?",
@@ -2525,7 +2488,7 @@ directory."""
     )
     parser.add_argument(
         "--precision",
-        type=nat0,
+        type=argcheck.as_nonnegi,
         default=config.DEFT_FLOAT_PRINT_PRECISION,
         help="Precision with which to print stats",
     )

--- a/src/pydrobert/torch/data.py
+++ b/src/pydrobert/torch/data.py
@@ -47,6 +47,7 @@ from ._dataloaders import (
     SpectDataLoaderParams,
     SpectEvaluationDataLoader,  # deprecated
     SpectTrainingDataLoader,  # deprecated
+    OnUnevenDistributed,
 )
 from ._parsing import (
     parse_arpa_lm,


### PR DESCRIPTION
This PR cleans up argument checking in the various pytorch modules (and in the CLI). The `argcheck` submodule is introduced, which contains functions for a variety of type checking and comparison operators. No notable changes in functionality.