### PR TITLE
LookupLanguageModel refactoring + reimplementing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added `pydrobert.torch.argcheck` and standardized module argument checking a
   bit.
+- Added `environment.yml` for local dev.
 - `LookupLanguageModel` has been refactored and reimplemented. It is no longer
   compatible with previous versions of the model.
 - `parse_arpa` has been enhanced: it can handle log-probs in scientific

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,14 @@
 ## v0.4.0
 
 - Added `pydrobert.torch.argcheck` and standardized module argument checking a
-  bit
-- `parse_arpa` can handle log-probs in scientific notation (e.g. `1e4`)
+  bit.
+- `LookupLanguageModel` has been refactored and reimplemented. It is no longer
+  compatible with previous versions of the model.
+- `parse_arpa` has been enhanced: it can handle log-probs in scientific
+  notation (e.g. `1e4`), conversion from (implicitly) log-base-10 to log-base-e
+  probabilities; and storing log probabilities as Numpy floating-point types.
+- `LookupLanguageModel` and `parse_arpa` now have an optional logger argument
+  to log progress building the trie and parsing the file, respectively.
 - Added `best_is_train` flag to `TrainingController.update_for_epoch`
 - Refactored `get-torch-spect-data-dir-info` to be faster
 - `subset-torch-spect-data-dir` command has been added

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,18 @@
+# Micromamba environment file
+# https://marketplace.visualstudio.com/items?itemName=corker.vscode-micromamba
+
+name: default
+
+channels:
+  - sdrobert
+  - pytorch
+  - conda-forge
+
+dependencies:
+  - pytorch
+  - python
+  - pytorch-lightning>=1.7
+  - pydrobert-param>=0.4.0
+  - pytest
+  - webdataset
+  - pydrobert-speech>=0.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,4 @@
-# Micromamba environment file
-# https://marketplace.visualstudio.com/items?itemName=corker.vscode-micromamba
-
-name: default
+name: pydrobert-torch
 
 channels:
   - sdrobert

--- a/environment.yml
+++ b/environment.yml
@@ -16,3 +16,4 @@ dependencies:
   - pytest
   - webdataset
   - pydrobert-speech>=0.2.0
+  - ipython

--- a/src/pydrobert/torch/_lm.py
+++ b/src/pydrobert/torch/_lm.py
@@ -450,7 +450,7 @@ def _lookup_calc_idx_log_probs(
     vrange = torch.arange(V + 1, device=device, dtype=torch.long)
     hidx = torch.as_tensor(hidx, dtype=torch.long, device=device).expand(B)
     srange = vrange[:S]
-    desc = torch.cat([vrange[:V].repeat(B), hist[-1]])  # (M + B,)
+    desc = torch.cat([vrange[:V].repeat(B), hist[-1].long()])  # (M + B,)
     last_logps = last_logps.repeat(B)  # (M,)
     last_backoffs = logbs[desc[M:]].repeat_interleave(V)  # (M,)
     found = torch.ones(M + B, device=device, dtype=torch.bool)
@@ -560,8 +560,6 @@ class LookupLanguageModel(MixableSequentialLanguageModel):
     >>> # save state dict, quit, startup, then reload state dict
     >>> lm = LookupLanguageModel(vocab_size, sos)  # fast!
     >>> lm.load_state_dict(state_dict)
-
-    In addition, while this module does not 
 
     See Also
     --------
@@ -777,6 +775,22 @@ class LookupLanguageModel(MixableSequentialLanguageModel):
     def calc_full_log_probs_chunked(
         self, hist: torch.Tensor, prev: Dict[str, torch.Tensor], chunk_size: int = 1,
     ) -> torch.Tensor:
+        """Computes full log probabilities in chunks
+        
+        This method has the same signature and interpretation as
+        :func:`calc_full_log_probs`, but with an additional optional argument
+        `chunk_size`. Because
+
+        Parameters
+        ----------
+        hist
+        prev
+        chunk_size
+
+        Returns
+        -------
+        log_probs : torch.Tensor
+        """
         T, B = hist.shape
         N, V = self.max_ngram, self.vocab_size
         Nm1, device = min(T, N - 1), hist.device

--- a/src/pydrobert/torch/_lm.py
+++ b/src/pydrobert/torch/_lm.py
@@ -654,7 +654,7 @@ class LookupLanguageModel(MixableSequentialLanguageModel):
         vocab_size: int,
         sos: int,
         prob_dicts: Optional[ProbDicts] = None,
-        destructive: bool = True,
+        destructive: bool = False,
         *,
         prob_list: Optional[ProbDicts] = None,
     ):

--- a/src/pydrobert/torch/_lm.py
+++ b/src/pydrobert/torch/_lm.py
@@ -435,6 +435,8 @@ def _lookup_calc_idx_log_probs(
     #
     # back:  C -> B -> A
     #                       = P(D|A, B, C)
+    #
+    # some additional, irritating details are commented on in the loop.
     vrange = torch.arange(V + 2, device=device, dtype=torch.long)
     hidx = torch.as_tensor(hidx, dtype=torch.long, device=device).expand(B)
     srange = vrange[:S]
@@ -486,7 +488,7 @@ def _lookup_calc_idx_log_probs(
         # print(n, "cur_backoffs", cur_backoffs[i])
         logps_desc = logps[desc[:M]]
         # print(n, "logps_desc", logps_desc[i])
-        is_finite = logps_desc.isfinite()
+        is_finite = torch.isfinite(logps_desc)
         # print(n, "is_finite", is_finite[i])
         hit_match = hit[:M] & hit_match
         # print(n, "hit", hit_match[i], hit[M + i])

--- a/src/pydrobert/torch/_lm.py
+++ b/src/pydrobert/torch/_lm.py
@@ -458,9 +458,10 @@ def _lookup_calc_idx_log_probs(
     if shift:
         hist = hist.masked_fill(hist.eq(sos), V)
         # hist = hist + shift
+    hist = hist.to(ids.dtype)
 
     # add the possible extensions to the history
-    cur_step = torch.arange(0, V, dtype=torch.long, device=device)
+    cur_step = vrange = torch.arange(V, dtype=torch.long, device=device)
     cur_step = cur_step.view(1, 1, V).expand(1, B, V)
     hist = torch.cat([hist.unsqueeze(2).expand(N - 1, B, V), cur_step], 0)
 
@@ -473,7 +474,6 @@ def _lookup_calc_idx_log_probs(
     hist = hist.view(-1, M)  # pretend M is batch; reshape at end
     out = torch.zeros(M, dtype=torch.float, device=device)
     running_mask = torch.full(out.shape, 1, dtype=torch.bool, device=device)
-    vrange = torch.arange(V, dtype=torch.int32, device=device)
     children = tokens = hist[0]
     for Nn in range(N - 1):
         n = N - Nn

--- a/src/pydrobert/torch/_lm.py
+++ b/src/pydrobert/torch/_lm.py
@@ -802,10 +802,7 @@ class LookupLanguageModel(MixableSequentialLanguageModel):
             if is_last:
                 self.max_ngram_nodes = len(prob_dict)
         if self.shift:
-            prob_dicts[0] = dict(
-                (self.vocab_size, v) if k == self.sos else (k, v)
-                for (k, v) in list(prob_dicts[0].items())
-            )
+            prob_dicts[0][self.vocab_size] = prob_dicts[0].pop(self.sos)
             for n in range(1, self.max_ngram):
                 prob_dicts[n] = dict(
                     (tuple(self.vocab_size if t == self.sos else t for t in k), v)

--- a/src/pydrobert/torch/_lm.py
+++ b/src/pydrobert/torch/_lm.py
@@ -32,7 +32,6 @@ try:
     def insort_left(sl: SortedList, x):
         sl.add(x)
 
-
 except ImportError:
     from bisect import insort_left
 
@@ -172,7 +171,10 @@ class SequentialLanguageModel(torch.nn.Module, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def calc_idx_log_probs(
-        self, hist: torch.Tensor, prev: Dict[str, torch.Tensor], idx: torch.Tensor,
+        self,
+        hist: torch.Tensor,
+        prev: Dict[str, torch.Tensor],
+        idx: torch.Tensor,
     ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
         """Calculates log_prob_idx over types at prefix up to and excluding idx
 
@@ -759,7 +761,10 @@ class LookupLanguageModel(MixableSequentialLanguageModel):
         return 0 if (0 <= self.sos < self.vocab_size) else 1
 
     def calc_idx_log_probs(
-        self, hist: torch.Tensor, prev: Dict[str, torch.Tensor], idx: torch.Tensor,
+        self,
+        hist: torch.Tensor,
+        prev: Dict[str, torch.Tensor],
+        idx: torch.Tensor,
     ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
         return (
             _lookup_calc_idx_log_probs(
@@ -780,21 +785,26 @@ class LookupLanguageModel(MixableSequentialLanguageModel):
 
     @torch.jit.export
     def calc_full_log_probs(
-        self, hist: torch.Tensor, prev: Dict[str, torch.Tensor],
+        self,
+        hist: torch.Tensor,
+        prev: Dict[str, torch.Tensor],
     ) -> torch.Tensor:
         return self.calc_full_log_probs_chunked(hist, prev, 1)
 
     @torch.jit.export
     def calc_full_log_probs_chunked(
-        self, hist: torch.Tensor, prev: Dict[str, torch.Tensor], chunk_size: int = 1,
+        self,
+        hist: torch.Tensor,
+        prev: Dict[str, torch.Tensor],
+        chunk_size: int = 1,
     ) -> torch.Tensor:
         """Computes full log probabilities in chunks
-        
+
         This method has the same interpretation and return value as
         :func:`calc_full_log_probs`, but with an additional optional argument
         `chunk_size` to control the number of distributions over tokens to compute
         simultaneously.
-        
+
         Because the distribution over the current token does not depend on any prior
         state, it is possible to compute all token distributions simultaneously. While
         faster, it is also much more memory-intensive to do so (especially so for large

--- a/src/pydrobert/torch/_lm.py
+++ b/src/pydrobert/torch/_lm.py
@@ -594,11 +594,10 @@ class LookupLanguageModel(MixableSequentialLanguageModel):
 
     Warnings
     --------
-    After 0.3.0, `prob_list` was renamed to `prob_dicts`. `prob_list` is deprecated
-
-    After 0.3.0, `sos` became no longer optional. `pad_sos_to_n` was removed as an
-    argument (implicitly true now). `eos` and `oov` were also removed as part of updates
-    to :obj:`SequentialLanguageModel`
+    After 0.3.0, `prob_list` was renamed to `prob_dicts`. `prob_list` is deprecated.
+    `sos` became no longer optional. `pad_sos_to_n` was removed as an argument
+    (implicitly true now). `eos` and `oov` were also removed as part of updates to
+    :obj:`SequentialLanguageModel`
 
     JIT scripting is possible with this module, but not tracing.
     """

--- a/src/pydrobert/torch/_lm.py
+++ b/src/pydrobert/torch/_lm.py
@@ -620,13 +620,11 @@ class LookupLanguageModel(MixableSequentialLanguageModel):
     # flat buffers "ids", "logps", and "logbs" respectively, with values accessible by
     # index. Indices satisfy the following invariants:
     #
-    # 1. The direct descendants of the root are the entire vocabulary, ordered 0...V
+    # 1. The direct descendants of the root are the entire vocabulary, sorted by id
     # 2. All nodes of level n occur before (in index) those of level n + 1
-    # 3. If two nodes i and j are on the same level and i < j, then all the direct
+    # 3. Direct descendants of a node are sorted by id
+    # 4. If two nodes i and j are on the same level and i < j, then all the direct
     #    descendants of i (and thus all descendants of i) occur before those of j
-    #
-    # The order of direct descendants (after level 1) is unspecified unless sort=True,
-    # at which point they are sorted in ascending numeric order.
     #
     # Unigram nodes always occupy the first `vocab_size` indices. When the maximal order
     # of the trie is > 1, the trie may be navigated with the buffer `offsets`. The value

--- a/src/pydrobert/torch/_lm.py
+++ b/src/pydrobert/torch/_lm.py
@@ -525,8 +525,8 @@ class LookupLanguageModel(MixableSequentialLanguageModel):
         Pr(w_t|w_{t-1},\ldots,w_{t-(N-1)}) = \begin{cases}
             Entry(w_{t-(N-1)}, w_{t-(N-1)+1}, \ldots, w_t)
                 & \text{if } Entry(w_{t-(N-1)}, \ldots) > 0 \\
-            Backoff(w_{t-(N-1)}, \ldots, w_{t-1})
-            Pr(w_t|w_{t-1},\ldots,w_{t-(N-1)+1}) & \text{else}
+            Backoff(w_{t-(N-1)}, \ldots, w_{t-1}) Pr(w_t|w_{t-1},\ldots,w_{t-(N-1)+1}) &
+            \text{else}
         \end{cases}
 
     Missing entries are assumed to have value 0 and missing backoff penalties are
@@ -534,8 +534,7 @@ class LookupLanguageModel(MixableSequentialLanguageModel):
 
     Parameters
     ----------
-    vocab_size
-    sos
+    vocab_size sos
         The start of sequence token. If specified, any prefix with fewer tokens than the
         maximum order of n-grams minus 1 will be prepended up to that length with this
         token.
@@ -548,27 +547,28 @@ class LookupLanguageModel(MixableSequentialLanguageModel):
         values are pairs of log-probability and log-backoff penalty. If `prob_dicts` is
         not specified, a unigram model with a uniform prior will be built.
     destructive
-        If :obj:`True`, allows initialization to modify `prob_dicts` directly instead
-        of making a fresh copy. Doing so can help reduce memory pressure.
+        If :obj:`True`, allows initialization to modify `prob_dicts` directly instead of
+        making a fresh copy. Doing so can help reduce memory pressure.
     logger
         If specified, this logger will be used to report on the progress initializing
         this module.
-    
-    Call Parameters
-    ---------------
-    hist : torch.Tensor
-    prev : Dict[str, torch.Tensor], optional
-    idx : Optional[Union[int, torch.Tensor]], optional
 
-    Returns
-    -------
-    log_probs : torch.Tensor or tuple of torch.Tensor
+    Warnings
+    --------
+    This class differs considerably from its `0.3.0` version. `prob_list` was renamed to
+    `prob_dicts`; `prob_list` is deprecated. `sos` became no longer optional.
+    `pad_sos_to_n` was removed as an argument (implicitly true now). `eos` and `oov`
+    were also removed as part of updates to :obj:`SequentialLanguageModel`. Finally, the
+    underlying buffers of this model have changed in structure and name, invalidating
+    any old saved state dictionaries.
+
+    JIT scripting is possible with this module, but not tracing.
 
     Notes
     -----
     Initializing an instance from an `prob_dicts` is expensive. `prob_dicts` is
-    converted to a trie (something like [heafield2011]_) so that it takes up less space
-    in memory, which can take some time.
+    converted to a reverse trie (something like [heafield2011]_) so that it takes up
+    less space in memory, which can take some time.
 
     Rather than re-initializing repeatedly, it is recommended you save and load this
     module's state dict. :func:`load_state_dict` as been overridden to support loading
@@ -584,19 +584,11 @@ class LookupLanguageModel(MixableSequentialLanguageModel):
 
     See Also
     --------
+    SequentialLanguageModel
+        A general description of language models, including call parameters
     pydrobert.util.parse_arpa_lm
-        How to read a pretrained table of n-gram probabilities into
-        `prob_dicts`. The parameter `token2id` should be specified to ensure
-        id-based keys.
-
-    Warnings
-    --------
-    After 0.3.0, `prob_list` was renamed to `prob_dicts`. `prob_list` is deprecated.
-    `sos` became no longer optional. `pad_sos_to_n` was removed as an argument
-    (implicitly true now). `eos` and `oov` were also removed as part of updates to
-    :obj:`SequentialLanguageModel`
-
-    JIT scripting is possible with this module, but not tracing.
+        How to read a pretrained table of n-gram probabilities into `prob_dicts`. The
+        parameter `token2id` should be specified to ensure id-based keys.
     """
 
     __constants__ = (

--- a/src/pydrobert/torch/argcheck.py
+++ b/src/pydrobert/torch/argcheck.py
@@ -36,7 +36,6 @@ import string
 
 from typing import (
     Collection,
-    Concatenate,
     Optional,
     TypeVar,
     Callable,
@@ -47,7 +46,7 @@ from typing import (
     Generic,
     cast,
 )
-from typing_extensions import overload, Literal, get_args, ParamSpec
+from typing_extensions import overload, Literal, get_args, ParamSpec, Concatenate
 from pathlib import Path
 
 import torch
@@ -221,6 +220,20 @@ def is_in(val, collection, name=None, allow_none=False):
         return None
     if val not in collection:
         raise ValueError(f"{_nv(name, val)} is not one of {collection}")
+    return val
+
+
+@_is_check_allow_none
+def is_file(val: StrOrPathLike, name: Optional[str] = None) -> StrOrPathLike:
+    if not os.path.isfile(val):
+        raise ValueError(f"{_nv(name, val)} is not a file")
+    return val
+
+
+@_is_check_allow_none
+def is_dir(val: StrOrPathLike, name: Optional[str] = None) -> StrOrPathLike:
+    if not os.path.isdir(val):
+        raise ValueError(f"{_nv(name, val)} is not a directory")
     return val
 
 
@@ -798,20 +811,6 @@ is_nat = is_posi
     is_open01t,
     is_closed01t,
 ) = _numlike_special_factory(torch.Tensor)
-
-
-@_is_check_allow_none
-def is_file(val: StrOrPathLike, name: Optional[str] = None) -> StrOrPathLike:
-    if not os.path.isfile(val):
-        raise ValueError(f"{_nv(name, val)} is not a file")
-    return val
-
-
-@_is_check_allow_none
-def is_dir(val: StrOrPathLike, name: Optional[str] = None) -> StrOrPathLike:
-    if not os.path.isdir(val):
-        raise ValueError(f"{_nv(name, val)} is not a directory")
-    return val
 
 
 @overload

--- a/src/pydrobert/torch/argcheck.py
+++ b/src/pydrobert/torch/argcheck.py
@@ -864,16 +864,15 @@ def _cast_factory(
     def _cast(val: Any, name: Optional[str] = None) -> V1:
         try:
             val = cast(val)
+            if check is not None:
+                val = check(val, name)
         except:
             suf = "n" if _cast.__name__.startswith(("a", "e", "i", "o", "u")) else ""
             raise TypeError(
-                f"Could not cast {_nv(name, val)} as a{suf} {_cast.__name__}"
+                f"Could not cast {_nv(name, val)} as a{suf} {cast.__name__}"
             )
-        if _cast.check is not None:
-            val = _cast.check(val, name)
         return val
 
-    _cast.check = check
     _cast.__name__ = cast.__name__ if cast_name is None else cast_name
 
     return _cast

--- a/src/pydrobert/torch/argcheck.py
+++ b/src/pydrobert/torch/argcheck.py
@@ -42,11 +42,17 @@ from typing import (
     Any,
     Type,
     Union,
-    Protocol,
     Generic,
     cast,
 )
-from typing_extensions import overload, Literal, get_args, ParamSpec, Concatenate
+from typing_extensions import (
+    overload,
+    Literal,
+    get_args,
+    ParamSpec,
+    Concatenate,
+    Protocol,
+)
 from pathlib import Path
 
 import torch
@@ -833,7 +839,9 @@ def has_ndim(
     ...
 
 
-def has_ndim(val, ndim, name=None) -> torch.Tensor:
+def has_ndim(val, ndim, name=None, allow_none=False) -> torch.Tensor:
+    if allow_none and val is None:
+        return val
     if val.ndim != ndim:
         raise ValueError(
             f"Expected {_nv(name, val)} to have dimension {ndim}; got {val.ndim}"

--- a/tests/test_argcheck.py
+++ b/tests/test_argcheck.py
@@ -112,6 +112,8 @@ def test_is_type(check, val, exp):
         (argcheck.is_btw_open, 1, (0.999, 1), False),
         (argcheck.is_btw_closed, 1, (1, 1), True),
         (argcheck.is_btw_closed, 1.001, (1, 1), False),
+        (argcheck.has_ndim, torch.empty(1, 2, 3), (3,), True),
+        (argcheck.has_ndim, torch.empty(0), (3,), False),
     ],
 )
 def test_comparative(check, val, rest, good):

--- a/tests/test_argcheck.py
+++ b/tests/test_argcheck.py
@@ -106,6 +106,12 @@ def test_is_type(check, val, exp):
         (argcheck.is_gte, torch.full((5,), np.inf), (10_000,), True),
         (argcheck.is_gte, 1, (1.0,), True),
         (argcheck.is_gte, 0, (torch.arange(2),), False),
+        (argcheck.is_btw, 30.5, (0.1, np.inf), True),
+        (argcheck.is_btw, 30.5, (0.1, -np.inf), False),
+        (argcheck.is_btw_open, 1, (0.999, 1.001), True),
+        (argcheck.is_btw_open, 1, (0.999, 1), False),
+        (argcheck.is_btw_closed, 1, (1, 1), True),
+        (argcheck.is_btw_closed, 1.001, (1, 1), False),
     ],
 )
 def test_comparative(check, val, rest, good):

--- a/tests/test_argcheck.py
+++ b/tests/test_argcheck.py
@@ -123,3 +123,43 @@ def test_comparative(check, val, rest, good):
         with pytest.raises(ValueError):
             check(val, *rest)
     assert check(None, *rest, allow_none=True) is None
+
+
+@pytest.mark.parametrize(
+    "check,val,exp",
+    [
+        (argcheck.as_str, 1, "1"),
+        (argcheck.as_int, "1", 1),
+        (argcheck.as_int, "1.1", None),
+        (argcheck.as_bool, 0, False),
+        (argcheck.as_bool, -1, True),
+        (argcheck.as_tensor, 0.0, torch.tensor(0.0)),
+        (argcheck.as_tensor, (0, 1), torch.arange(2)),
+        (argcheck.as_tensor, "foo", None),
+        (argcheck.as_posf, "3e10", 3e10),
+        (argcheck.as_nat, "100", 100),
+        (argcheck.as_nat, "1.0", None),
+        (argcheck.as_nat, "0", None),
+        (argcheck.as_nonnegi, "0", 0),
+        (argcheck.as_nonnegi, "-1", None),
+        (argcheck.as_open01, "-1", None),
+        (argcheck.as_open01, "1e-5", 1e-5),
+        (argcheck.as_closed01, "0", 0.0),
+        (argcheck.as_path, ".", Path(".")),
+        (argcheck.as_path_file, ".", None),
+        (argcheck.as_path_dir, __file__, None),
+        (argcheck.as_dir, Path("."), "."),
+        (argcheck.as_file, __file__, __file__),
+    ],
+)
+def test_as(check, val, exp):
+    if exp is None:
+        with pytest.raises(TypeError):
+            check(val)
+    else:
+        act = check(val)
+        assert type(exp) is type(act)
+        if isinstance(act, torch.Tensor):
+            assert (exp == act).all()
+        else:
+            assert exp == act

--- a/tests/test_argcheck.py
+++ b/tests/test_argcheck.py
@@ -1,0 +1,117 @@
+# Copyright 2023 Sean Robertson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import pytest
+import numpy as np
+
+from pathlib import Path
+
+from pydrobert.torch import argcheck
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "check,val,exp",
+    [
+        (argcheck.is_str, "a", "a"),
+        (argcheck.is_str, "", ""),
+        (argcheck.is_str, bytes("a", "utf-8"), None),
+        (argcheck.is_int, 1, 1),
+        (argcheck.is_int, -1, -1),
+        (argcheck.is_int, np.uint32(1), 1),
+        (argcheck.is_int, 1.0, None),
+        (argcheck.is_int, np.float32(1.0), None),
+        (argcheck.is_bool, True, True),
+        (argcheck.is_bool, False, False),
+        (argcheck.is_bool, 1, None),
+        (argcheck.is_bool, "", None),
+        (argcheck.is_float, 1.0, 1.0),
+        (argcheck.is_float, np.inf, np.inf),
+        (argcheck.is_float, 1, 1.0),
+        (argcheck.is_float, np.float64(3.14), 3.14),
+        (argcheck.is_float, np.uint8(255), 255.0),
+        (argcheck.is_tensor, torch.ones(5), torch.ones(5)),
+        (argcheck.is_tensor, 1, None),
+        (argcheck.is_path, Path("."), Path(".")),
+        (argcheck.is_path, ".", Path(".")),
+        (argcheck.is_path, b".", None),
+        (argcheck.is_numlike, 1, 1),
+        (argcheck.is_numlike, 1.0, 1.0),
+        (argcheck.is_numlike, "", None),
+        (argcheck.is_token, "foo", "foo"),
+        (argcheck.is_token, "", None),
+        (argcheck.is_token, "foo bar", None),
+        (argcheck.is_posi, 1, 1),
+        (argcheck.is_posi, np.uint8(2), 2),
+        (argcheck.is_posi, 1.0, None),
+        (argcheck.is_posi, 0, None),
+        (argcheck.is_nonposf, -1.0, -1.0),
+        (argcheck.is_nonposf, -1, -1.0),
+        (argcheck.is_nonposf, np.uint8(0), 0.0),
+        (argcheck.is_nonposf, 1.0, None),
+        (argcheck.is_closed01t, torch.arange(2), torch.arange(2)),
+        (argcheck.is_closed01t, 1, None),
+        (argcheck.is_closed01t, -torch.arange(2), None),
+        (argcheck.is_open01t, torch.full((5,), 0.5), torch.full((5,), 0.5)),
+        (argcheck.is_open01t, 0.5, None),
+        (argcheck.is_open01t, torch.arange(2), None),
+        (argcheck.is_file, __file__, __file__),
+        (argcheck.is_file, Path.cwd(), None),
+        (argcheck.is_dir, Path.cwd(), Path.cwd()),
+        (argcheck.is_dir, __file__, None),
+        (argcheck.is_nonempty, torch.ones(1), torch.ones(1)),
+        (argcheck.is_nonempty, torch.ones(0), None),
+    ],
+)
+def test_is_type(check, val, exp):
+    if exp is None:
+        with pytest.raises(ValueError):
+            check(val)
+    else:
+        act = check(val)
+        assert type(exp) is type(act)
+        if isinstance(act, torch.Tensor):
+            assert (exp == act).all()
+        else:
+            assert exp == act
+        assert check(None, allow_none=True) is None
+
+
+@pytest.mark.parametrize(
+    "check,val,rest,good",
+    [
+        (argcheck.is_a, 1, (int,), True),
+        (argcheck.is_a, 1, (float,), False),
+        (argcheck.is_in, 2, (range(10),), True),
+        (argcheck.is_in, "1", (range(10),), False),
+        (argcheck.is_exactly, 1, (1,), True),
+        (argcheck.is_exactly, 1, (1.0,), False),
+        (argcheck.is_equal, 1, (1.0,), True),
+        (argcheck.is_equal, torch.ones(2, 1), (torch.ones(1, 2),), True),
+        (argcheck.is_equal, torch.ones(2, 1), (torch.arange(2),), False),
+        (argcheck.is_lt, 1, (torch.arange(2) + 2,), True),
+        (argcheck.is_lt, 1.0, (torch.arange(2) + 1,), False),
+        (argcheck.is_gte, torch.full((5,), np.inf), (10_000,), True),
+        (argcheck.is_gte, 1, (1.0,), True),
+        (argcheck.is_gte, 0, (torch.arange(2),), False),
+    ],
+)
+def test_comparative(check, val, rest, good):
+    if good:
+        assert check(val, *rest) is val
+    else:
+        with pytest.raises(ValueError):
+            check(val, *rest)
+    assert check(None, *rest, allow_none=True) is None

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -440,7 +440,7 @@ def test_lookup_language_model_state_dict():
                     lm_b.logps.masked_select(nan_mask.eq(0)),
                     atol=1e-5,
                 )
-                & (nan_mask == torch.isnan(lm_b.logps)).all()
+                & (nan_mask == torch.isnan(lm_b.logps)).all().item()
             )
             nan_mask = torch.isnan(lm_a.logbs)
             same_logs &= (
@@ -449,7 +449,7 @@ def test_lookup_language_model_state_dict():
                     lm_b.logbs.masked_select(nan_mask.eq(0)),
                     atol=1e-5,
                 )
-                & (nan_mask == torch.isnan(lm_b.logbs)).all()
+                & (nan_mask == torch.isnan(lm_b.logbs)).all().item()
             )
         if assert_same:
             assert same_max_ngram

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -344,7 +344,9 @@ def test_lookup_language_model_nonuniform_idx(device):
                 dict_[key] = torch.randn((2,), device=device).tolist()
         prob_dicts.append(dict_)
     prob_dicts[0][sos] = (-99, 0)
-    lm = LookupLanguageModel(vocab_size, sos, prob_dicts=prob_dicts).to(device)
+    lm = LookupLanguageModel(
+        vocab_size, sos, prob_dicts=prob_dicts, destructive=True
+    ).to(device)
     hist = torch.randint(0, vocab_size, (S, B), device=device)
     exp = lm(hist)
     idx = torch.randint(0, S + 1, (B,), device=device)
@@ -360,7 +362,7 @@ def test_lookup_language_model_sos_context(device):
         {(0, 1): (0.01, -0.01), (0, 2): (0.02, -0.02)},
         {(0, 0, 1): 0.001},
     ]
-    lm = LookupLanguageModel(4, sos=0, prob_dicts=prob_dicts)
+    lm = LookupLanguageModel(4, sos=0, prob_dicts=prob_dicts, destructive=True)
     lm.to(device)
     # XXX(sdrobert): pad_sos_to_n has been removed now - it's always true
     # P(0|0, 0) = P(0) = -99
@@ -412,7 +414,9 @@ def test_lookup_language_model_republic():
     exp = torch.tensor(exp, device=device)
     assert exp.shape[0] == queries.shape[1]
     prob_dicts = parse_arpa_lm(arpa_file, token2id=token2id)
-    lm = LookupLanguageModel(vocab_size, sos=sos, prob_dicts=prob_dicts)
+    lm = LookupLanguageModel(
+        vocab_size, sos=sos, prob_dicts=prob_dicts, destructive=True
+    )
     lm = lm.to(device)
     log_probs = lm(queries)
     queries = torch.cat([queries, torch.full_like(queries[:1], eos)])

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -398,7 +398,7 @@ def test_lookup_language_model_republic():
             exp.append(float(line))
     exp = torch.tensor(exp, device=device)
     assert exp.shape[0] == queries.shape[1]
-    prob_dicts = parse_arpa_lm(arpa_file, token2id, np.float32)
+    prob_dicts = parse_arpa_lm(arpa_file, token2id, False, np.float32)
     lm = LookupLanguageModel(
         vocab_size, sos=sos, prob_dicts=prob_dicts, destructive=True
     )

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -19,6 +19,7 @@ from typing import Dict, Tuple
 
 import torch
 import pytest
+import numpy as np
 
 from pydrobert.torch.modules import (
     LookupLanguageModel,
@@ -243,7 +244,7 @@ def test_lookup_language_model_log_probs(device, N, jit_type):
     vocab_size, sos = 10, -1
     prob_dicts = []
     for n in range(1, N + 1):
-        max_ngrams = vocab_size ** n
+        max_ngrams = vocab_size**n
         has_ngram = torch.randint(2, (max_ngrams,), device=device).eq(1)
         dict_ = dict()
         last = n == N
@@ -323,7 +324,7 @@ def test_lookup_language_model_nonuniform_idx(device):
     vocab_size, sos = 10, -1
     prob_dicts = []
     for n in range(1, N + 1):
-        max_ngrams = vocab_size ** n
+        max_ngrams = vocab_size**n
         has_ngram = torch.randint(2, (max_ngrams,), device=device).eq(1)
         dict_ = dict()
         last = n == N
@@ -413,7 +414,7 @@ def test_lookup_language_model_republic():
             exp.append(float(line))
     exp = torch.tensor(exp, device=device)
     assert exp.shape[0] == queries.shape[1]
-    prob_dicts = parse_arpa_lm(arpa_file, token2id=token2id)
+    prob_dicts = parse_arpa_lm(arpa_file, token2id, np.float32)
     lm = LookupLanguageModel(
         vocab_size, sos=sos, prob_dicts=prob_dicts, destructive=True
     )

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -334,7 +334,7 @@ def test_lookup_language_model_nonuniform_idx(device):
     ).to(device)
     hist = torch.randint(0, vocab_size, (S, B), device=device)
     exp = lm(hist)
-    assert not exp.isnan().any()
+    assert not torch.isnan(exp).any()
     idx = torch.randint(0, S + 1, (B,), device=device)
     exp = exp.gather(0, idx.view(1, B, 1).expand(1, B, vocab_size)).squeeze(0)
     act, _ = lm(hist, idx=idx)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -59,7 +59,7 @@ ngram 2=7
 """
     )
     file_.seek(0)
-    ngram_list = data.parse_arpa_lm(file_, ftype=ftype)
+    ngram_list = data.parse_arpa_lm(file_, to_base_e=False, ftype=ftype)
     assert len(ngram_list) == 2
     assert set(ngram_list[0]) == {
         "<unk>",
@@ -86,7 +86,7 @@ ngram 2=7
     assert abs(ngram_list[1][("cindy", "jean")] + 0.2553) < 1e-4
     file_.seek(0)
     token2id = dict((c, hash(c)) for c in ngram_list[0])
-    ngram_list = data.parse_arpa_lm(file_, token2id, ftype)
+    ngram_list = data.parse_arpa_lm(file_, token2id, False, ftype)
     assert set(ngram_list[0]) == set(token2id.values())
     file_.seek(0)
     file_.write(
@@ -103,7 +103,7 @@ ngram 10 = 1
 """
     )
     file_.seek(0)
-    ngram_list = data.parse_arpa_lm(file_, ftype=ftype)
+    ngram_list = data.parse_arpa_lm(file_, to_base_e=False, ftype=ftype)
     assert all(x == dict() for x in ngram_list[:-1])
     assert not ngram_list[9][tuple(str(x) for x in range(1, 11))]
     file_.seek(0)
@@ -122,7 +122,7 @@ ngram 1 = 1
     )
     file_.seek(0)
     with pytest.raises(IOError):
-        data.parse_arpa_lm(file_)
+        data.parse_arpa_lm(file_, to_base_e=False)
     file_.seek(0)
     file_.write(
         r"""\
@@ -133,7 +133,7 @@ Here's an empty one
 """
     )
     file_.seek(0)
-    assert data.parse_arpa_lm(file_) == []
+    assert data.parse_arpa_lm(file_, to_base_e=True) == []
 
 
 @pytest.mark.cpu

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -17,12 +17,16 @@ from tempfile import SpooledTemporaryFile
 
 import pytest
 import torch
+import numpy as np
 
 import pydrobert.torch.data as data
 
 
 @pytest.mark.cpu
-def test_parse_arpa_lm():
+@pytest.mark.parametrize(
+    "ftype", [float, np.float32, np.float64], ids=["pyfloat", "f32", "f64"]
+)
+def test_parse_arpa_lm(ftype):
     file_ = SpooledTemporaryFile(mode="w+")
     file_.write(
         r"""\
@@ -55,7 +59,7 @@ ngram 2=7
 """
     )
     file_.seek(0)
-    ngram_list = data.parse_arpa_lm(file_)
+    ngram_list = data.parse_arpa_lm(file_, ftype=ftype)
     assert len(ngram_list) == 2
     assert set(ngram_list[0]) == {
         "<unk>",
@@ -75,13 +79,14 @@ ngram 2=7
         ("jean", "</s>"),
         ("jean", "wood"),
     }
+    assert isinstance(ngram_list[0]["<unk>"][0], ftype)
     assert abs(ngram_list[0]["cindy"][0] + 0.6990) < 1e-4
     assert abs(ngram_list[0]["pittsburgh"][0] + 0.6990) < 1e-4
     assert abs(ngram_list[0]["jean"][1] + 0.1973) < 1e-4
     assert abs(ngram_list[1][("cindy", "jean")] + 0.2553) < 1e-4
     file_.seek(0)
     token2id = dict((c, hash(c)) for c in ngram_list[0])
-    ngram_list = data.parse_arpa_lm(file_, token2id=token2id)
+    ngram_list = data.parse_arpa_lm(file_, token2id, ftype)
     assert set(ngram_list[0]) == set(token2id.values())
     file_.seek(0)
     file_.write(
@@ -98,7 +103,7 @@ ngram 10 = 1
 """
     )
     file_.seek(0)
-    ngram_list = data.parse_arpa_lm(file_)
+    ngram_list = data.parse_arpa_lm(file_, ftype=ftype)
     assert all(x == dict() for x in ngram_list[:-1])
     assert not ngram_list[9][tuple(str(x) for x in range(1, 11))]
     file_.seek(0)
@@ -321,7 +326,13 @@ last A 0.0 10.0111 hullo
     "transcript,token2id,unk,skip_frame_times,exp",
     [
         ([], None, None, False, torch.LongTensor(0, 3)),
-        ([1, 2, 3, 4], None, None, True, torch.LongTensor([1, 2, 3, 4]),),
+        (
+            [1, 2, 3, 4],
+            None,
+            None,
+            True,
+            torch.LongTensor([1, 2, 3, 4]),
+        ),
         (
             [1, ("a", 4, 10), "a", 3],
             {"a": 2},


### PR DESCRIPTION
This PR follows a lot of parallel work in my SCPC and pytorch-database-prep projects, getting large n-gram models working for Librispeech. Much of the code in LookupLanguageModel has been completely reimplemented, relying on a reverse trie under the hood rather than a nested loop. It is more efficient in general to build these tries, in part due to some algorithmic changes and in part by allowing `prob_list` (i.e. the ARPA model) to be built with lower-precision floats and integers. Finally, we now allow `parse_arpa_lm` to convert log probabilities to log-base-e, the standard base of PyTorch and other DL frameworks.

Changelog:
- Added `environment.yml` for local dev.
- `LookupLanguageModel` has been refactored and reimplemented. It is no longer
  compatible with previous versions of the model.
- `parse_arpa` has been enhanced: it can handle log-probs in scientific
  notation (e.g. `1e4`), conversion from (implicitly) log-base-10 to log-base-e
  probabilities; and storing log probabilities as Numpy floating-point types.
- `LookupLanguageModel` and `parse_arpa` now have an optional logger argument
  to log progress building the trie and parsing the file, respectively.